### PR TITLE
Modification of the generated new notebook name

### DIFF
--- a/src/Services/FileManager.vala
+++ b/src/Services/FileManager.vala
@@ -148,7 +148,8 @@ public class ENotes.FileManager : Object {
     }
 
     public static string create_notebook (string name, double r, double g, double b, string source = NOTES_DIR) {
-        string notebook_name = "%s§%.3f§%.3f§%.3f".printf (name,r,g,b);
+        string notebook_name = "%s§%s§%s§%s".printf(name, r.to_string(),g.to_string(),b.to_string());
+
         var directory = File.new_for_path (source + notebook_name);
         try {
             directory.make_directory_with_parents ();


### PR DESCRIPTION
I have the same problem of the issue #39 and the modification of generated new notebook name resolved the bug for me.
The generated name has now the same result than the editing notebook name.

I see how are saved the notebook and i think it respect the linux logic: "Everything is a file", and i like it! :+1: 