### PR TITLE
Reduce Bookmark and Search Buttons Sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,85 @@
+
+# Created by https://www.gitignore.io/api/c,cmake
+
+### C ###
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+### CMake ###
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+
+# End of https://www.gitignore.io/api/c,cmake
+
+build/
+
+# Ignore config.vala as it is generated with cmake
+src/config.vala
+
+# Ignore generated files of discount
+deps/discount/blocktags
+deps/discount/config.*
+deps/discount/libmarkdown*
+deps/discount/librarian.sh
+deps/discount/markdown
+deps/discount/mkdio.h
+deps/discount/mktags
+deps/discount/src/
+deps/discount/tmp/
+deps/discount/version.c

--- a/src/Widgets/BookmarkButton.vala
+++ b/src/Widgets/BookmarkButton.vala
@@ -34,7 +34,7 @@ public class ENotes.BookmarkButton : Gtk.Button {
     }
 
     private BookmarkButton () {
-        pic = new Gtk.Image.from_icon_name ("non-starred",  Gtk.IconSize.LARGE_TOOLBAR);
+        pic = new Gtk.Image.from_icon_name ("non-starred",  Gtk.IconSize.BUTTON);
 
         this.image = pic;
 
@@ -53,9 +53,9 @@ public class ENotes.BookmarkButton : Gtk.Button {
 
     public void setup () {
         if (BookmarkTable.get_instance ().is_bookmarked (this.current_page)) {
-            pic.set_from_icon_name ("starred", Gtk.IconSize.DIALOG);
+            pic.set_from_icon_name ("starred", Gtk.IconSize.BUTTON);
         } else {
-            pic.set_from_icon_name ("non-starred", Gtk.IconSize.DIALOG);
+            pic.set_from_icon_name ("non-starred", Gtk.IconSize.BUTTON);
         }
     }
 

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -78,7 +78,7 @@ public class ENotes.Headerbar : Gtk.HeaderBar {
         search_entry_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT;
         search_button_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT;
 
-        search_button = new Gtk.Button.from_icon_name ("edit-find-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        search_button = new Gtk.Button.from_icon_name ("edit-find-symbolic", Gtk.IconSize.BUTTON);
         search_button.tooltip_text = (_("Search your current notebook") + Key.FIND.to_string ());
         search_button.clicked.connect(show_search);
 

--- a/src/config.vala
+++ b/src/config.vala
@@ -1,9 +1,0 @@
-namespace Constants {
-   public const string DATADIR = "/usr/share";
-   public const string PKGDATADIR = "/usr/share/notes-up";
-   public const string GETTEXT_PACKAGE = "notes-up";
-   public const string RELEASE_NAME = "TARS";
-   public const string VERSION = "0.7";
-   public const string VERSION_INFO = "Release";
-   public const string INSTALL_PREFIX = "/usr";
-}


### PR DESCRIPTION
On Gnome 3.22, whenever I try to run the application, the size of the headerbar is enormous. I have a feeling it was due to the size of Bookmark and Search buttons. This fix will make the size of the two buttons 16px which should match that of the other buttons in the headerbar.