### PR TITLE
Reduced the size of the Bookmark and Search button

### DIFF
--- a/src/Widgets/BookmarkButton.vala
+++ b/src/Widgets/BookmarkButton.vala
@@ -34,7 +34,7 @@ public class ENotes.BookmarkButton : Gtk.Button {
     }
 
     private BookmarkButton () {
-        pic = new Gtk.Image.from_icon_name ("non-starred",  Gtk.IconSize.LARGE_TOOLBAR);
+        pic = new Gtk.Image.from_icon_name ("non-starred",  Gtk.IconSize.BUTTON);
 
         this.image = pic;
 
@@ -53,9 +53,9 @@ public class ENotes.BookmarkButton : Gtk.Button {
 
     public void setup () {
         if (BookmarkTable.get_instance ().is_bookmarked (this.current_page)) {
-            pic.set_from_icon_name ("starred", Gtk.IconSize.DIALOG);
+            pic.set_from_icon_name ("starred", Gtk.IconSize.BUTTON);
         } else {
-            pic.set_from_icon_name ("non-starred", Gtk.IconSize.DIALOG);
+            pic.set_from_icon_name ("non-starred", Gtk.IconSize.BUTTON);
         }
     }
 

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -78,7 +78,7 @@ public class ENotes.Headerbar : Gtk.HeaderBar {
         search_entry_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT;
         search_button_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT;
 
-        search_button = new Gtk.Button.from_icon_name ("edit-find-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        search_button = new Gtk.Button.from_icon_name ("edit-find-symbolic", Gtk.IconSize.BUTTON);
         search_button.tooltip_text = (_("Search your current notebook") + Key.FIND.to_string ());
         search_button.clicked.connect(show_search);
 


### PR DESCRIPTION
On Gnome 3.22, whenever I try to run the application, the size of the headerbar is enormous. I have a feeling it was due to the size of Bookmark and Search buttons. This fix will make the size of the two buttons 16px which should match that of the other buttons in the headerbar.