### PR TITLE
Fixes bookmark button from increasing to 48px

### DIFF
--- a/src/Widgets/BookmarkButton.vala
+++ b/src/Widgets/BookmarkButton.vala
@@ -53,9 +53,9 @@ public class ENotes.BookmarkButton : Gtk.Button {
 
     public void setup () {
         if (BookmarkTable.get_instance ().is_bookmarked (this.current_page)) {
-            pic.set_from_icon_name ("starred", Gtk.IconSize.DIALOG);
+            pic.set_from_icon_name ("starred", Gtk.IconSize.LARGE_TOOLBAR);
         } else {
-            pic.set_from_icon_name ("non-starred", Gtk.IconSize.DIALOG);
+            pic.set_from_icon_name ("non-starred", Gtk.IconSize.LARGE_TOOLBAR);
         }
     }
 


### PR DESCRIPTION
Was there a reason why Gtk.IconSize.DIALOG was used when clicking the BookmarkButton? This appears to fix the issues that I was having using Notes-Up on Gnome 3.20. 