### PR TITLE
Fix warning message about transient window

### DIFF
--- a/src/Widgets/NewNotebookDialog.vala
+++ b/src/Widgets/NewNotebookDialog.vala
@@ -32,6 +32,7 @@ public class ENotes.NotebookDialog : Gtk.Dialog {
 
     public NotebookDialog (Notebook? notebook = null) {
         this.notebook = notebook;
+        set_transient_for (window);
         build_ui ();
         connect_signals ();
 

--- a/src/Widgets/PreferencesDialog.vala
+++ b/src/Widgets/PreferencesDialog.vala
@@ -33,6 +33,7 @@ public class ENotes.PreferencesDialog : Gtk.Dialog {
     private Gtk.Switch keep_sidebar_switch;
 
     public PreferencesDialog () {
+        set_transient_for (window);
         build_ui ();
         connect_signals ();
     }


### PR DESCRIPTION
This should help the window managers keep the Dialog boxes on top of the main window.