### PR TITLE
Packaging fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,10 +192,8 @@ file(GLOB assets "${CMAKE_CURRENT_SOURCE_DIR}/data/assets/**")
 install (FILES ${assets}
   DESTINATION ${DATADIR}/notes-up/)
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/data/com.github.philip-scott.notes-up.svg"
-  DESTINATION ${DATADIR}/pixmaps/)
+  DESTINATION share/icons/hicolor/scalable/apps)
 
 # App DATA
 #configure_file_translation (io.github.notes-up.xml.in ${CMAKE_CURRENT_BINARY_DIR}/io.github.notes-up.xml ${CMAKE_SOURCE_DIR}/po/)
 #install (FILES ${CMAKE_CURRENT_BINARY_DIR}/io.github.notes-up.xml DESTINATION ${DATADIR}/appdata/)
-
-

--- a/data/com.github.philip-scott.notes-up.appdata.xml
+++ b/data/com.github.philip-scott.notes-up.appdata.xml
@@ -21,6 +21,15 @@
     <binary>notes-up</binary>
   </provides>
   <releases>
+    <release version="1.4.3" date="2017-06-06">
+      <description>
+        <p>Quick fix</p>
+        <ul>
+          <li>Prevent crash when closing the preferences dialog</li>
+          <li>Make sure to load all plugins</li>
+        </ul>
+      </description>
+    </release>
   </releases>
   <screenshots>
     <screenshot type="default">

--- a/data/com.github.philip-scott.notes-up.desktop
+++ b/data/com.github.philip-scott.notes-up.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Notes-Up
 Comment=Your markdown notebook
-Exec=/usr/bin/notes-up
+Exec=notes-up
 Icon=com.github.philip-scott.notes-up
 Terminal=false
 Type=Application


### PR DESCRIPTION
I noticed these issues while creating a Flatpak. The icon is now being installed to the correct location, the Appdata file validates and the desktop file works when installing Notes-up into another prefix.

Flathub pull-request: https://github.com/flathub/flathub/pull/45

If you're interested, you can maintain the Flathub repo as well.