### PR TITLE
Use title like in elementary HIG

### DIFF
--- a/src/Widgets/Editor.vala
+++ b/src/Widgets/Editor.vala
@@ -226,7 +226,7 @@ public class ENotes.Editor : Gtk.Box {
     public void show_line_numbers (bool show) {
         code_view.set_show_line_numbers (show);
 
-        if (show) {a
+        if (show) {
             code_view.left_margin = 6;
         } else {
             code_view.left_margin = 12;

--- a/src/Widgets/Editor.vala
+++ b/src/Widgets/Editor.vala
@@ -43,7 +43,8 @@ public class ENotes.Editor : Gtk.Box {
             code_buffer.text = value.data;
 
             edited = false;
-            ENotes.Headerbar.get_instance ().set_title (value.name);
+            string notebook_title = NotebookTable.get_instance().load_notebook_data(value.notebook_id).name;
+            ENotes.Headerbar.get_instance ().set_title (value.name, notebook_title);
             code_buffer.end_not_undoable_action ();
 
             set_sensitive (true);
@@ -225,7 +226,7 @@ public class ENotes.Editor : Gtk.Box {
     public void show_line_numbers (bool show) {
         code_view.set_show_line_numbers (show);
 
-        if (show) {
+        if (show) {a
             code_view.left_margin = 6;
         } else {
             code_view.left_margin = 12;

--- a/src/Widgets/Editor.vala
+++ b/src/Widgets/Editor.vala
@@ -43,8 +43,6 @@ public class ENotes.Editor : Gtk.Box {
             code_buffer.text = value.data;
 
             edited = false;
-            string notebook_title = NotebookTable.get_instance().load_notebook_data(value.notebook_id).name;
-            ENotes.Headerbar.get_instance ().set_title (value.name, notebook_title);
             code_buffer.end_not_undoable_action ();
 
             set_sensitive (true);

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -146,11 +146,16 @@ public class ENotes.Headerbar : Gtk.HeaderBar {
         mode_button.set_active (mode);
     }
 
-    public new void set_title (string? title) {
-        if (title != null) {
-            this.title = title + " - Notes-Up";
+    public new void set_title (string? page_title, string? notebook_title) {
+        if (page_title != null && notebook_title != null) {
+            this.title = page_title + " - " + notebook_title;
+        else if (page_title != null) {
+            this.title = page_title + " - ";
+        }
+        else if (notebook_title != null){
+            this.title = " - " + notebook_title;
         } else {
-            this.title = "Notes-Up";
+            this.title = "";
         }
     }
 

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -90,7 +90,7 @@ public class ENotes.Headerbar : Gtk.HeaderBar {
 
         bookmark_button = BookmarkButton.get_instance ();
 
-        set_title (null);
+        set_title (null, null);
         set_show_close_button (true);
 
         pack_start (mode_button);

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -147,12 +147,16 @@ public class ENotes.Headerbar : Gtk.HeaderBar {
     }
 
     public new void set_title (string? page_title, string? notebook_title) {
-    
-        string left_side = page_title != null ? page_title : "";
-        string right_side = notebook_title != null ? notebook_title : "";
-        
-        this.title = page_title != "" & notebook_title != "" ? page_title + " - " + notebook_title : "";
-    
+        if (page_title != null && notebook_title != null) {
+            this.title = page_title + " - " + notebook_title;
+        else if (page_title != null) {
+            this.title = page_title + " - ";
+        }
+        else if (notebook_title != null) {
+            this.title = " - " + notebook_title;
+        } else {
+            this.title = "";
+        }
     
     
     

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -151,7 +151,7 @@ public class ENotes.Headerbar : Gtk.HeaderBar {
             this.title = page_title + " - " + notebook_title;
         } else if (page_title != null) {
             this.title = page_title + " - ";
-        } else if (notebook_title != null){
+        } else if (notebook_title != null) {
             this.title = " - " + notebook_title;
         } else {
             this.title = "";

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -147,15 +147,15 @@ public class ENotes.Headerbar : Gtk.HeaderBar {
     }
 
     public new void set_title (string? page_title, string? notebook_title) {
-        if (page_title != null && notebook_title != null) {
-            this.title = page_title + " - " + notebook_title;
-        } else if (page_title != null) {
-            this.title = page_title + " - ";
-        } else if (notebook_title != null) {
-            this.title = " - " + notebook_title;
-        } else {
-            this.title = "";
-        }
+    
+        string left_side = page_title != null ? page_title : "";
+        string right_side = notebook_title != null ? notebook_title : "";
+        
+        this.title = page_title != "" & notebook_title != "" ? page_title + " - " + notebook_title : "";
+    
+    
+    
+    
     }
 
     private void connect_signals () {

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -149,17 +149,13 @@ public class ENotes.Headerbar : Gtk.HeaderBar {
     public new void set_title (string? page_title, string? notebook_title) {
         if (page_title != null && notebook_title != null) {
             this.title = page_title + " - " + notebook_title;
-        else if (page_title != null) {
+        } else if (page_title != null) {
             this.title = page_title + " - ";
-        }
-        else if (notebook_title != null) {
+        } else if (notebook_title != null) {
             this.title = " - " + notebook_title;
         } else {
             this.title = "";
         }
-    
-    
-    
     }
 
     private void connect_signals () {

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -149,10 +149,9 @@ public class ENotes.Headerbar : Gtk.HeaderBar {
     public new void set_title (string? page_title, string? notebook_title) {
         if (page_title != null && notebook_title != null) {
             this.title = page_title + " - " + notebook_title;
-        else if (page_title != null) {
+        } else if (page_title != null) {
             this.title = page_title + " - ";
-        }
-        else if (notebook_title != null){
+        } else if (notebook_title != null){
             this.title = " - " + notebook_title;
         } else {
             this.title = "";

--- a/src/Widgets/PagesList.vala
+++ b/src/Widgets/PagesList.vala
@@ -261,7 +261,7 @@ public class ENotes.PagesList : Gtk.Box {
 
         minus_button.clicked.connect (() => {
             ENotes.Editor.get_instance ().set_sensitive (false);
-            Headerbar.get_instance().set_title (null);
+            Headerbar.get_instance().set_title (null, null);
 
             var rows = listbox.get_selected_rows ();
 
@@ -299,4 +299,4 @@ public class ENotes.PagesList : Gtk.Box {
     private void translations () {
         ngettext ("%i Page", "%i Pages", 0);
     }
-}
+}\

--- a/src/Widgets/PagesList.vala
+++ b/src/Widgets/PagesList.vala
@@ -299,4 +299,4 @@ public class ENotes.PagesList : Gtk.Box {
     private void translations () {
         ngettext ("%i Page", "%i Pages", 0);
     }
-}\
+}

--- a/src/Widgets/ViewEditStack.vala
+++ b/src/Widgets/ViewEditStack.vala
@@ -81,13 +81,9 @@ public class ENotes.ViewEditStack : Gtk.Overlay {
         current_page = PageTable.get_instance ().get_page (page.id);
         editor.current_page = current_page;
         viewer.load_page (current_page);
-
         
-        
-        Notebook ntbook = ENotes.NotebookTable.get_instance().load_notebook_data(current_page.notebook_id);
-        string notebook_title = ntbook.name;
-        ENotes.Headerbar.get_instance ().set_title (page.name, notebook_title);
-
+        var ntbook = ENotes.NotebookTable.get_instance().load_notebook_data(current_page.notebook_id);
+        ENotes.Headerbar.get_instance ().set_title (page.name, ntbook.name);
 
         bookmark_button.set_page (current_page);
         page_set (current_page);

--- a/src/Widgets/ViewEditStack.vala
+++ b/src/Widgets/ViewEditStack.vala
@@ -82,7 +82,10 @@ public class ENotes.ViewEditStack : Gtk.Overlay {
         editor.current_page = current_page;
         viewer.load_page (current_page);
 
-        string notebook_title = NotebookTable.get_instance().load_notebook_data(page.notebook_id).name;
+        
+        
+        Notebook ntbook = ENotes.NotebookTable.get_instance().load_notebook_data(current_page.notebook_id);
+        string notebook_title = ntbook.name;
         ENotes.Headerbar.get_instance ().set_title (page.name, notebook_title);
 
 

--- a/src/Widgets/ViewEditStack.vala
+++ b/src/Widgets/ViewEditStack.vala
@@ -76,11 +76,15 @@ public class ENotes.ViewEditStack : Gtk.Overlay {
                 return;
             }
         }
-
+        
         editor.save_file ();
         current_page = PageTable.get_instance ().get_page (page.id);
         editor.current_page = current_page;
         viewer.load_page (current_page);
+
+        string notebook_title = NotebookTable.get_instance().load_notebook_data(page.notebook_id).name;
+        ENotes.Headerbar.get_instance ().set_title (page.name, notebook_title);
+
 
         bookmark_button.set_page (current_page);
         page_set (current_page);


### PR DESCRIPTION
The elementary HIG stated that window title shouldn't use the apps name. 
https://elementary.io/de/docs/human-interface-guidelines#windows


Instead of using page name + " - Notes - Up" the application uses the schema pagename + " - " + notebook name.
The new solution gives also a better view which notebook is used.