### PR TITLE
Better summary for pages

### DIFF
--- a/src/Plugins/Break.vala
+++ b/src/Plugins/Break.vala
@@ -55,7 +55,6 @@ public class ENotes.Break : ENotes.Plugin {
         return line_.replace ("<break>", """<div style="page-break-after: always;">&zwnj;</div>""");
     }
     
-    
     public override Gee.List<BLMember> get_blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
         list.add (new BLMember (/<break>/, ""));

--- a/src/Plugins/Break.vala
+++ b/src/Plugins/Break.vala
@@ -54,4 +54,11 @@ public class ENotes.Break : ENotes.Plugin {
     public override string convert (string line_) {
         return line_.replace ("<break>", """<div style="page-break-after: always;">&zwnj;</div>""");
     }
+    
+    
+    public override Gee.LinkedList<BLMember> blacklist_members () {
+        var list = new Gee.LinkedList<BLMember> ();
+        list.add (new BLMember (/<break>/, ""));
+        return list;
+    }
 }

--- a/src/Plugins/Break.vala
+++ b/src/Plugins/Break.vala
@@ -56,7 +56,7 @@ public class ENotes.Break : ENotes.Plugin {
     }
     
     
-    public override Gee.List<BLMember> blacklist_members () {
+    public override Gee.List<BLMember> get_blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
         list.add (new BLMember (/<break>/, ""));
         return list;

--- a/src/Plugins/Break.vala
+++ b/src/Plugins/Break.vala
@@ -56,7 +56,7 @@ public class ENotes.Break : ENotes.Plugin {
     }
     
     
-    public override Gee.LinkedList<BLMember> blacklist_members () {
+    public override Gee.List<BLMember> blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
         list.add (new BLMember (/<break>/, ""));
         return list;

--- a/src/Plugins/Color.vala
+++ b/src/Plugins/Color.vala
@@ -107,7 +107,7 @@ public class ENotes.Color : ENotes.Plugin {
         return builed + line[last:i];
     }
     
-    public override Gee.LinkedList<BLMember> blacklist_members () {
+    public override Gee.List<BLMember> blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
         list.add (new BLMember (/<color #[\da-zA-Z]{6}>/, ""));
         return list;

--- a/src/Plugins/Color.vala
+++ b/src/Plugins/Color.vala
@@ -109,7 +109,7 @@ public class ENotes.Color : ENotes.Plugin {
     
     public override Gee.List<BLMember> get_blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
-        list.add (new BLMember (/<color #[\da-zA-Z]{6}>/, ""));
+        list.add (new BLMember (/<color #[\d\p{L}]{6}>/, ""));
         return list;
     }
 }

--- a/src/Plugins/Color.vala
+++ b/src/Plugins/Color.vala
@@ -106,4 +106,10 @@ public class ENotes.Color : ENotes.Plugin {
 
         return builed + line[last:i];
     }
+    
+    public override Gee.LinkedList<BLMember> blacklist_members () {
+        var list = new Gee.LinkedList<BLMember> ();
+        list.add (new BLMember (/<color #[\da-zA-Z]{6}>/, ""));
+        return list;
+    }
 }

--- a/src/Plugins/Color.vala
+++ b/src/Plugins/Color.vala
@@ -107,7 +107,7 @@ public class ENotes.Color : ENotes.Plugin {
         return builed + line[last:i];
     }
     
-    public override Gee.List<BLMember> blacklist_members () {
+    public override Gee.List<BLMember> get_blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
         list.add (new BLMember (/<color #[\da-zA-Z]{6}>/, ""));
         return list;

--- a/src/Plugins/Highlight.vala
+++ b/src/Plugins/Highlight.vala
@@ -56,7 +56,7 @@ public class ENotes.Highlight : ENotes.Plugin {
 <script>hljs.initHighlightingOnLoad();</script>""");
     }
     
-    public override Gee.List<BLMember> blacklist_members () {
+    public override Gee.List<BLMember> get_blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
         list.add (new BLMember (/<highlight>/, ""));
         return list;

--- a/src/Plugins/Highlight.vala
+++ b/src/Plugins/Highlight.vala
@@ -56,7 +56,7 @@ public class ENotes.Highlight : ENotes.Plugin {
 <script>hljs.initHighlightingOnLoad();</script>""");
     }
     
-    public override Gee.LinkedList<BLMember> blacklist_members () {
+    public override Gee.List<BLMember> blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
         list.add (new BLMember (/<highlight>/, ""));
         return list;

--- a/src/Plugins/Highlight.vala
+++ b/src/Plugins/Highlight.vala
@@ -55,4 +55,10 @@ public class ENotes.Highlight : ENotes.Plugin {
 <script src="/usr/share/notes-up/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>""");
     }
+    
+    public override Gee.LinkedList<BLMember> blacklist_members () {
+        var list = new Gee.LinkedList<BLMember> ();
+        list.add (new BLMember (/<highlight>/, ""));
+        return list;
+    }
 }

--- a/src/Plugins/Image.vala
+++ b/src/Plugins/Image.vala
@@ -64,4 +64,10 @@ public class ENotes.ImagePlugin : ENotes.Plugin {
 
         return data.str;
     }
+    
+    public override Gee.LinkedList<BLMember> blacklist_members () {
+        var list = new Gee.LinkedList<BLMember> ();
+        list.add (new BLMember (/<image \d+>/, ""));
+        return list;
+    }
 }

--- a/src/Plugins/Image.vala
+++ b/src/Plugins/Image.vala
@@ -65,7 +65,7 @@ public class ENotes.ImagePlugin : ENotes.Plugin {
         return data.str;
     }
     
-    public override Gee.List<BLMember> blacklist_members () {
+    public override Gee.List<BLMember> get_blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
         list.add (new BLMember (/<image \d+>/, ""));
         return list;

--- a/src/Plugins/Image.vala
+++ b/src/Plugins/Image.vala
@@ -65,7 +65,7 @@ public class ENotes.ImagePlugin : ENotes.Plugin {
         return data.str;
     }
     
-    public override Gee.LinkedList<BLMember> blacklist_members () {
+    public override Gee.List<BLMember> blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
         list.add (new BLMember (/<image \d+>/, ""));
         return list;

--- a/src/Plugins/Manager.vala
+++ b/src/Plugins/Manager.vala
@@ -51,5 +51,15 @@ public class ENotes.PluginManager : GLib.Object {
     }
     
     
-     
+    public Gee.List<BLMember> get_all_blacklist_members () {
+        var result = new Gee.LinkedList<BLMember> ();
+        foreach (Plugin plugin in plug_list){
+            if (plugin.get_blacklist_members () != null) {
+                foreach (BLMember blacklist_member in plugin.get_blacklist_members ()) {
+                    result.add (blacklist_member);
+                }
+            }
+        }
+        return result;
+    }
 }

--- a/src/Plugins/Manager.vala
+++ b/src/Plugins/Manager.vala
@@ -49,4 +49,7 @@ public class ENotes.PluginManager : GLib.Object {
     public unowned Plugin[] get_plugs () {
         return plug_list;
     }
+    
+    
+     
 }

--- a/src/Plugins/Manager.vala
+++ b/src/Plugins/Manager.vala
@@ -50,7 +50,6 @@ public class ENotes.PluginManager : GLib.Object {
         return plug_list;
     }
     
-    
     public Gee.List<BLMember> get_all_blacklist_members () {
         var result = new Gee.LinkedList<BLMember> ();
         foreach (Plugin plugin in plug_list){

--- a/src/Plugins/Plugin.vala
+++ b/src/Plugins/Plugin.vala
@@ -51,10 +51,15 @@ public abstract class ENotes.Plugin : GLib.Object {
     public virtual string request_string (string selection) {
         return selection;
     }
+    
+    // if plugin doesnt say anything about syntax just return null
+    public virtual Gee.LinkedList<BLMember> blacklist_members () {
+        return null;
+    }
 }
 
 // Describs member of BlackList used in cleanup. reg is the regular expression and replace the string it will be replaced
-public struct BLMember {
+public class BLMember {
     public GLib.Regex reg;
     public string replace;
     

--- a/src/Plugins/Plugin.vala
+++ b/src/Plugins/Plugin.vala
@@ -58,7 +58,7 @@ public abstract class ENotes.Plugin : GLib.Object {
     }
 }
 
-// Describs member of BlackList used in cleanup. reg is the regular expression and replace the string it will be replaced
+// Describes member of BlackList used in cleanup. reg is the regular expression and replace the string it will be replaced
 public class BLMember {
     public GLib.Regex reg;
     public string replace;

--- a/src/Plugins/Plugin.vala
+++ b/src/Plugins/Plugin.vala
@@ -53,7 +53,7 @@ public abstract class ENotes.Plugin : GLib.Object {
     }
     
     // if plugin doesnt say anything about syntax just return null
-    public virtual Gee.List<BLMember> blacklist_members () {
+    public virtual Gee.List<BLMember> get_blacklist_members () {
         return null;
     }
 }

--- a/src/Plugins/Plugin.vala
+++ b/src/Plugins/Plugin.vala
@@ -52,3 +52,14 @@ public abstract class ENotes.Plugin : GLib.Object {
         return selection;
     }
 }
+
+// Describs member of BlackList used in cleanup. reg is the regular expression and replace the string it will be replaced
+public struct BLMember {
+    public GLib.Regex reg;
+    public string replace;
+    
+    public BLMember (GLib.Regex reg, string replace) {
+        this.reg = reg;
+        this.replace = replace;
+    }
+}

--- a/src/Plugins/Plugin.vala
+++ b/src/Plugins/Plugin.vala
@@ -53,7 +53,7 @@ public abstract class ENotes.Plugin : GLib.Object {
     }
     
     // if plugin doesnt say anything about syntax just return null
-    public virtual Gee.LinkedList<BLMember> blacklist_members () {
+    public virtual Gee.List<BLMember> blacklist_members () {
         return null;
     }
 }

--- a/src/Plugins/Youtube.vala
+++ b/src/Plugins/Youtube.vala
@@ -71,7 +71,7 @@ public class ENotes.Youtube : ENotes.Plugin {
         return builed + line[last:i];
     }
     
-    public override Gee.LinkedList<BLMember> blacklist_members () {
+    public override Gee.List<BLMember> blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
         // [a-zA-Z0-9_\.\?\/:\=\+&\-'"]* is very greedy way for stating website but closer solutions need more space 
         var youtube_video = new BLMember (/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));

--- a/src/Plugins/Youtube.vala
+++ b/src/Plugins/Youtube.vala
@@ -70,4 +70,11 @@ public class ENotes.Youtube : ENotes.Plugin {
 
         return builed + line[last:i];
     }
+    
+    public override Gee.LinkedList<BLMember> blacklist_members () {
+        var list = new Gee.LinkedList<BLMember> ();
+        var youtube_video = new BLMember (/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));
+        list.add (youtube_video);
+        return list;
+    }
 }

--- a/src/Plugins/Youtube.vala
+++ b/src/Plugins/Youtube.vala
@@ -74,8 +74,10 @@ public class ENotes.Youtube : ENotes.Plugin {
     public override Gee.List<BLMember> get_blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
         // [a-zA-Z0-9_\.\?\/:\=\+&\-'"]* is very greedy way for stating website but closer solutions need more space 
+        var empty_link = new BLMember (/<youtube \[Link\]>/, "");
         var youtube_video = new BLMember (/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));
         list.add (youtube_video);
+        list.add (empty_link);
         return list;
     }
 }

--- a/src/Plugins/Youtube.vala
+++ b/src/Plugins/Youtube.vala
@@ -73,6 +73,7 @@ public class ENotes.Youtube : ENotes.Plugin {
     
     public override Gee.LinkedList<BLMember> blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
+        // [a-zA-Z0-9_\.\?\/:\=\+&\-'"]* is very greedy way for stating website but closer solutions need more space 
         var youtube_video = new BLMember (/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));
         list.add (youtube_video);
         return list;

--- a/src/Plugins/Youtube.vala
+++ b/src/Plugins/Youtube.vala
@@ -71,7 +71,7 @@ public class ENotes.Youtube : ENotes.Plugin {
         return builed + line[last:i];
     }
     
-    public override Gee.List<BLMember> blacklist_members () {
+    public override Gee.List<BLMember> get_blacklist_members () {
         var list = new Gee.LinkedList<BLMember> ();
         // [a-zA-Z0-9_\.\?\/:\=\+&\-'"]* is very greedy way for stating website but closer solutions need more space 
         var youtube_video = new BLMember (/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));

--- a/src/Plugins/Youtube.vala
+++ b/src/Plugins/Youtube.vala
@@ -75,7 +75,7 @@ public class ENotes.Youtube : ENotes.Plugin {
         var list = new Gee.LinkedList<BLMember> ();
         // [a-zA-Z0-9_\.\?\/:\=\+&\-'"]* is very greedy way for stating website but closer solutions need more space 
         var empty_link = new BLMember (/<youtube \[Link\]>/, "");
-        var youtube_video = new BLMember (/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));
+        var youtube_video = new BLMember (/<youtube [\p{L}\d_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));
         list.add (youtube_video);
         list.add (empty_link);
         return list;

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -86,8 +86,7 @@ public class ENotes.PageTable : DatabaseTable {
         }
 
         set_table_name ("Page");
-        
-        
+          
         // @translator this code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
     
         // Explaination for link: Regex for [Something](Something). As greedy as editor on markdown
@@ -98,15 +97,12 @@ public class ENotes.PageTable : DatabaseTable {
     
         Regex_complex_commands.add (link);
         Regex_complex_commands.add (anchor);
-        
-        
+              
         var plugin_blacklist_member = PluginManager.get_instance ().get_all_blacklist_members ();
         
         foreach (BLMember blacklist_member in plugin_blacklist_member) {
             Regex_complex_commands.add(blacklist_member);
-        }
-        
-        
+        }    
     }
 
     public Page? get_page (int64 page_id) {

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -219,9 +219,6 @@ public class ENotes.PageTable : DatabaseTable {
         }
     }
 
-    
-    
-    
     // Describs member of BlackList used in cleanup. reg is the regular expression and replace the string it will be replaced
     private struct BLMember {
         public GLib.Regex reg;
@@ -233,8 +230,7 @@ public class ENotes.PageTable : DatabaseTable {
         }
     
     }
-    
-    
+      
     private string cleanup (string line) {
  
     // This list is used for complex commands mostly by plugins e.g. "" <youtube [Link]>
@@ -244,7 +240,7 @@ public class ENotes.PageTable : DatabaseTable {
     // [a-zA-Z0-9_\.\?\/:\=\+&\-'"]* is very greedy way for stating website but closer solutions need more space 
        BLMember youtube_video = BLMember(/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));
     // "
-    // Explaination for link: Regex for [Something](Something). As greedy as editor
+    // Explaination for link: Regex for [Something](Something). As greedy as editor on markdown
        BLMember link = BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, _("Link"));
        
     //  \[\^\d+\]:? leads to e.g. [^32], [^68]:   
@@ -252,7 +248,7 @@ public class ENotes.PageTable : DatabaseTable {
        
     // Regex_Simple_elements used for symbols. Some symbols are part of more complex commands so these
     // list is used at the end
-    // first element replaces # ~ ` etc. with one regular expression 
+    // first regular expression replaces # ~ ` etc. with ""
         BLMember[] Regex_Simple_elements = {BLMember (/[#\n\t<>]+/, ""), BLMember(/<br>/, "")};
        
         string output = line;

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -227,7 +227,7 @@ public class ENotes.PageTable : DatabaseTable {
     // @translator this code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
 
     // Explaination for link: Regex for [Something](Something). As greedy as editor on markdown
-    var link = BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, _("Link"));
+    var link = new BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, _("Link"));
        
     //  \[\^\d+\]:? leads to e.g. [^32], [^68]: 
     var anchor = new BLMember (/\[\^\d+\]:?/, "");
@@ -256,7 +256,6 @@ public class ENotes.PageTable : DatabaseTable {
 
         if (line.contains ("---")) return "";
         
-        // What is the purpose of this line?
         if (output.contains ("&")) output = output.replace ("&","&amp;");
 
         if (output.length > 0 && output[0] == ' ') {

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -226,26 +226,26 @@ public class ENotes.PageTable : DatabaseTable {
        
     // @translator this code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
     // [a-zA-Z0-9_\.\?\/:\=\+&\-'"]* is very greedy way for stating website but closer solutions need more space 
-       var youtube_video = BLMember(/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));
+    //   var youtube_video = BLMember(/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));
     // "
     // Explaination for link: Regex for [Something](Something). As greedy as editor on markdown
-       var link = BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, _("Link"));
+    //   var link = BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, _("Link"));
        
     //  \[\^\d+\]:? leads to e.g. [^32], [^68]:   
-       Regex_complex_commands = {BLMember (/<break>/, ""), BLMember (/<highlight>/, ""), BLMember (/<color #[\da-zA-Z]{6}>/, ""), BLMember (/\[\^\d+\]:?/, ""), youtube_video, link};
+    //   Regex_complex_commands = {BLMember (/<break>/, ""), BLMember (/<highlight>/, ""), BLMember (/<color #[\da-zA-Z]{6}>/, ""), BLMember (/\[\^\d+\]:?/, ""), youtube_video, link};
        
     // Regex_Simple_elements used for symbols. Some symbols are part of more complex commands so these
     // list is used at the end
     // first regular expression replaces # ~ ` etc. with ""
-        BLMember[] Regex_Simple_elements = {BLMember (/[#\n\t<>]+/, ""), BLMember(/<br>/, "")};
+        BLMember[] Regex_Simple_elements = {new BLMember (/[#\n\t<>]+/, ""), new BLMember(/<br>/, "")};
        
         string output = line;
 
         try {
-            foreach (BLMember item in Regex_complex_commands) {
+     /*       foreach (BLMember item in Regex_complex_commands) {
                   output = item.reg.replace (output, -1, 0, item.replace);        
             }  
-        
+       */ 
             foreach (BLMember item in Regex_Simple_elements) {
                 output = item.reg.replace (output, -1, 0, item.replace);        
             }

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -251,9 +251,6 @@ public class ENotes.PageTable : DatabaseTable {
     //  \[\^\d+\]:? leads to e.g. [^32], [^68]:   
        Regex_complex_commands = {BLMember (/<break>/, ""), BLMember (/<highlight>/, ""), BLMember (/<color #[\da-zA-Z]{6}>/, ""), BLMember (/\[\^\d+\]:?/, ""), youtube_video, link};
        
-       
-    
-    
     // Regex_Simple_elements used for symbols. Some symbols are part of more complex commands so these
     // list is used at the end
     // first element replaces # ~ ` etc. with one regular expression 
@@ -270,18 +267,10 @@ public class ENotes.PageTable : DatabaseTable {
             output = item.reg.replace (output, -1, 0, item.replace);        
         }
         
-      
 
         if (line.contains ("---")) return "";
         
-        /*
-        foreach (string item in SYMBOLS_BLACKLIST) {
-            if (output.contains (item)) {
-                output = output.replace (item, "");
-            }
-        }
-        */
-
+        // What is the purpose of this line
         if (output.contains ("&")) output = output.replace ("&","&amp;");
 
         if (output.length > 0 && output[0] == ' ') {

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -52,7 +52,7 @@ public class ENotes.PageTable : DatabaseTable {
     // regex_simple_elements used for symbols. Some symbols are part of more complex commands so these
     // list is used at the end
     // first regular expression replaces # ~ ` etc. with ""
-    BLMember[] regex_simple_elements = {new BLMember (/[#\n\t<>]+/, ""), new BLMember(/<br>/, "")};
+    BLMember[] regex_simple_elements = {new BLMember (/[#\n\t<>`]+/, ""), new BLMember(/<br>/, "")};
 
     public static PageTable get_instance () {
         if (instance == null) {

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -89,7 +89,7 @@ public class ENotes.PageTable : DatabaseTable {
         ///This code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
     
         // Explaination for link: Regex for [Something](Something). As greedy as editor on markdown
-        var link = new BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'" ]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, "");
+        var link = new BLMember(/\[[\p{L}\d_\.\?\/:\=\+&\-'" ]*\]\([\p{L}\d_\.\?\/:\=\+&\-'"]*\)/, "");
        
         //  \[\^\d+\]:? leads to e.g. [^32], [^68]: 
         var anchor = new BLMember (/\[\^\d+\]:?/, "");

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -257,15 +257,17 @@ public class ENotes.PageTable : DatabaseTable {
        
         string output = line;
 
-
-        foreach (BLMember item in Regex_complex_commands) {
-              output = item.reg.replace (output, -1, 0, item.replace);        
-        }  
+        try {
+            foreach (BLMember item in Regex_complex_commands) {
+                  output = item.reg.replace (output, -1, 0, item.replace);        
+            }  
         
-        foreach (BLMember item in Regex_Simple_elements) {
-            output = item.reg.replace (output, -1, 0, item.replace);        
+            foreach (BLMember item in Regex_Simple_elements) {
+                output = item.reg.replace (output, -1, 0, item.replace);        
+            }
+        } catch (GLib.RegexError e) {
+            return "";
         }
-        
 
         if (line.contains ("---")) return "";
         

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -219,7 +219,7 @@ public class ENotes.PageTable : DatabaseTable {
         }
     }
 
-    //private const string[] SYMBOLS_BLACKLIST = {"#", "`", "\t", "<br>", ">", "<", "\n", "~" };
+    
     
     
     // Describs member of BlackList used in cleanup. reg is the regular expression and replace the string it will be replaced

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -237,16 +237,15 @@ public class ENotes.PageTable : DatabaseTable {
     
     private string cleanup (string line) {
  
- 
     // This list is used for complex commands mostly by plugins e.g. "" <youtube [Link]>
        BLMember[] Regex_complex_commands;
        
-       
+    // @translator this code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
     // [a-zA-Z0-9_\.\?\/:\=\+&\-'"]* is very greedy way for stating website but closer solutions need more space 
-       BLMember youtube_video = BLMember(/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, "Youtube Video");
+       BLMember youtube_video = BLMember(/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));
     // "
     // Explaination for link: Regex for [Something](Something). As greedy as editor
-       BLMember link = BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, "Link");
+       BLMember link = BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, _("Link"));
        
     //  \[\^\d+\]:? leads to e.g. [^32], [^68]:   
        Regex_complex_commands = {BLMember (/<break>/, ""), BLMember (/<highlight>/, ""), BLMember (/<color #[\da-zA-Z]{6}>/, ""), BLMember (/\[\^\d+\]:?/, ""), youtube_video, link};
@@ -270,7 +269,7 @@ public class ENotes.PageTable : DatabaseTable {
 
         if (line.contains ("---")) return "";
         
-        // What is the purpose of this line
+        // What is the purpose of this line?
         if (output.contains ("&")) output = output.replace ("&","&amp;");
 
         if (output.length > 0 && output[0] == ' ') {

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -89,12 +89,12 @@ public class ENotes.PageTable : DatabaseTable {
         ///This code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
     
         // Explaination for link: Regex for [Something](Something). As greedy as editor on markdown
-        var link = new BLMember(/\[[a-zA-Z0-9_ \.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, "");
+        var link = new BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'" ]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, "");
        
         //  \[\^\d+\]:? leads to e.g. [^32], [^68]: 
         var anchor = new BLMember (/\[\^\d+\]:?/, "");
             
-        var regex_complex_commands = PluginManager.get_instance ().get_all_blacklist_members ();
+        regex_complex_commands = (Gee.LinkedList) PluginManager.get_instance ().get_all_blacklist_members ();
         regex_complex_commands.add (link);
         regex_complex_commands.add (anchor);
           

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -222,17 +222,18 @@ public class ENotes.PageTable : DatabaseTable {
     private string cleanup (string line) {
  
     // This list is used for complex commands mostly by plugins e.g. "" <youtube [Link]>
-       BLMember[] Regex_complex_commands;
+       var Regex_complex_commands = new Gee.LinkedList<BLMember> ();
        
     // @translator this code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
-    // [a-zA-Z0-9_\.\?\/:\=\+&\-'"]* is very greedy way for stating website but closer solutions need more space 
-    //   var youtube_video = BLMember(/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));
-    // "
+
     // Explaination for link: Regex for [Something](Something). As greedy as editor on markdown
-    //   var link = BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, _("Link"));
+    var link = BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, _("Link"));
        
-    //  \[\^\d+\]:? leads to e.g. [^32], [^68]:   
-    //   Regex_complex_commands = {BLMember (/<break>/, ""), BLMember (/<highlight>/, ""), BLMember (/<color #[\da-zA-Z]{6}>/, ""), BLMember (/\[\^\d+\]:?/, ""), youtube_video, link};
+    //  \[\^\d+\]:? leads to e.g. [^32], [^68]: 
+    var anchor = new BLMember (/\[\^\d+\]:?/, "");
+    
+    Regex_complex_commands.add (link);
+    Regex_complex_commands.add (anchor);
        
     // Regex_Simple_elements used for symbols. Some symbols are part of more complex commands so these
     // list is used at the end

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -222,6 +222,7 @@ public class ENotes.PageTable : DatabaseTable {
     //private const string[] SYMBOLS_BLACKLIST = {"#", "`", "\t", "<br>", ">", "<", "\n", "~" };
     
     
+    // Describs member of BlackList. reg is the regular expression and replace the string it will be replaced
     private struct BLMember {
         public GLib.Regex reg;
         public string replace;
@@ -234,26 +235,37 @@ public class ENotes.PageTable : DatabaseTable {
     }
     
     
+    private string cleanup (string line) {
+ 
+ 
+    // This list is used for complex commands mostly by plugins e.g. "" <youtube [Link]>
+       BLMember[] Regex_complex_commands;
+       
+       
+       Regex_complex_commands = {BLMember (/<break>/, ""), BLMember (/<highlight>/, ""), BLMember (/<color #[\da-zA-Z]{6}>/, "")};
+       
+       
+    
+    
+    
+    // Regex_Simple_elements used for symbols. Some symbols are part of more complex commands so these
+    // list is used at the end
     // One element of REGEX_BLACKLIST has regular expression and then string to replace it
     // first element replaces # ~ ` etc. with one regular expression 
-    private string cleanup (string line) {
-        BLMember[] REGEX_BLACKLIST;
-        REGEX_BLACKLIST = {BLMember (/[#\n\t]+/, ""), BLMember(/<br>/, "")};
-        
-        
-        
-        
-        
-        //{/[#`\n\t~]+/, "", /<br>/, ""};
+        BLMember[] Regex_Simple_elements = {BLMember (/[#\n\t<>]+/, ""), BLMember(/<br>/, "")};
+       
         string output = line;
 
 
-  
-        foreach (BLMember b in REGEX_BLACKLIST) {
-            output = b.reg.replace (output, -1, 0, b.replace);        
+        foreach (BLMember item in Regex_complex_commands) {
+              output = item.reg.replace (output, -1, 0, item.replace);        
+        }  
+        
+        foreach (BLMember item in Regex_Simple_elements) {
+            output = item.reg.replace (output, -1, 0, item.replace);        
         }
         
-        if (output.contains ("#")) return "Fehler";
+      
 
         if (line.contains ("---")) return "";
         

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -47,12 +47,12 @@ public class ENotes.PageTable : DatabaseTable {
     private static PageTable instance = null;
     
     // This list is used for complex commands mostly by plugins e.g. "" <youtube [Link]>
-    private Gee.LinkedList<BLMember> Regex_complex_commands = new Gee.LinkedList<BLMember> ();
+    private Gee.LinkedList<BLMember> regex_complex_commands = new Gee.LinkedList<BLMember> ();
     
-    // Regex_Simple_elements used for symbols. Some symbols are part of more complex commands so these
+    // regex_simple_elements used for symbols. Some symbols are part of more complex commands so these
     // list is used at the end
     // first regular expression replaces # ~ ` etc. with ""
-    BLMember[] Regex_Simple_elements = {new BLMember (/[#\n\t<>]+/, ""), new BLMember(/<br>/, "")};
+    BLMember[] regex_simple_elements = {new BLMember (/[#\n\t<>]+/, ""), new BLMember(/<br>/, "")};
 
     public static PageTable get_instance () {
         if (instance == null) {
@@ -86,8 +86,7 @@ public class ENotes.PageTable : DatabaseTable {
         }
 
         set_table_name ("Page");
-          
-        // @translator this code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
+        /// @translator this code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
     
         // Explaination for link: Regex for [Something](Something). As greedy as editor on markdown
         var link = new BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, _("Link"));
@@ -95,13 +94,13 @@ public class ENotes.PageTable : DatabaseTable {
         //  \[\^\d+\]:? leads to e.g. [^32], [^68]: 
         var anchor = new BLMember (/\[\^\d+\]:?/, "");
     
-        Regex_complex_commands.add (link);
-        Regex_complex_commands.add (anchor);
+        regex_complex_commands.add (link);
+        regex_complex_commands.add (anchor);
               
         var plugin_blacklist_member = PluginManager.get_instance ().get_all_blacklist_members ();
         
         foreach (BLMember blacklist_member in plugin_blacklist_member) {
-            Regex_complex_commands.add(blacklist_member);
+            regex_complex_commands.add (blacklist_member);
         }    
     }
 
@@ -248,11 +247,11 @@ public class ENotes.PageTable : DatabaseTable {
         string output = line;
 
         try {
-            foreach (BLMember item in Regex_complex_commands) {
-                  output = item.reg.replace (output, -1, 0, item.replace);        
+            foreach (var item in regex_complex_commands) {
+                output = item.reg.replace (output, -1, 0, item.replace);        
             }  
         
-            foreach (BLMember item in Regex_Simple_elements) {
+            foreach (var item in regex_simple_elements) {
                 output = item.reg.replace (output, -1, 0, item.replace);        
             }
         } catch (GLib.RegexError e) {

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -219,17 +219,51 @@ public class ENotes.PageTable : DatabaseTable {
         }
     }
 
-    private const string[] SYMBOLS_BLACKLIST = {"#", "`", "\t", "<br>", ">", "<", "\n", "~" };
+    //private const string[] SYMBOLS_BLACKLIST = {"#", "`", "\t", "<br>", ">", "<", "\n", "~" };
+    
+    
+    private struct BLMember {
+        public GLib.Regex reg;
+        public string replace;
+        
+        public BLMember (GLib.Regex reg, string replace) {
+            this.reg = reg;
+            this.replace = replace;
+        }
+    
+    }
+    
+    
+    // One element of REGEX_BLACKLIST has regular expression and then string to replace it
+    // first element replaces # ~ ` etc. with one regular expression 
     private string cleanup (string line) {
+        BLMember[] REGEX_BLACKLIST;
+        REGEX_BLACKLIST = {BLMember (/[#\n\t]+/, ""), BLMember(/<br>/, "")};
+        
+        
+        
+        
+        
+        //{/[#`\n\t~]+/, "", /<br>/, ""};
         string output = line;
 
-        if (line.contains ("---")) return "";
 
+  
+        foreach (BLMember b in REGEX_BLACKLIST) {
+            output = b.reg.replace (output, -1, 0, b.replace);        
+        }
+        
+        if (output.contains ("#")) return "Fehler";
+
+        if (line.contains ("---")) return "";
+        
+        /*
         foreach (string item in SYMBOLS_BLACKLIST) {
             if (output.contains (item)) {
                 output = output.replace (item, "");
             }
         }
+        */
 
         if (output.contains ("&")) output = output.replace ("&","&amp;");
 

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -86,22 +86,18 @@ public class ENotes.PageTable : DatabaseTable {
         }
 
         set_table_name ("Page");
-        /// @translator this code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
+        ///This code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
     
         // Explaination for link: Regex for [Something](Something). As greedy as editor on markdown
         var link = new BLMember(/\[[a-zA-Z0-9_ \.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, "");
        
         //  \[\^\d+\]:? leads to e.g. [^32], [^68]: 
         var anchor = new BLMember (/\[\^\d+\]:?/, "");
-    
+            
+        var regex_complex_commands = PluginManager.get_instance ().get_all_blacklist_members ();
         regex_complex_commands.add (link);
         regex_complex_commands.add (anchor);
-              
-        var plugin_blacklist_member = PluginManager.get_instance ().get_all_blacklist_members ();
-        
-        foreach (BLMember blacklist_member in plugin_blacklist_member) {
-            regex_complex_commands.add (blacklist_member);
-        }    
+          
     }
 
     public Page? get_page (int64 page_id) {

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -218,18 +218,6 @@ public class ENotes.PageTable : DatabaseTable {
             page.subtitle = "";
         }
     }
-
-    // Describs member of BlackList used in cleanup. reg is the regular expression and replace the string it will be replaced
-    private struct BLMember {
-        public GLib.Regex reg;
-        public string replace;
-        
-        public BLMember (GLib.Regex reg, string replace) {
-            this.reg = reg;
-            this.replace = replace;
-        }
-    
-    }
       
     private string cleanup (string line) {
  
@@ -238,10 +226,10 @@ public class ENotes.PageTable : DatabaseTable {
        
     // @translator this code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
     // [a-zA-Z0-9_\.\?\/:\=\+&\-'"]* is very greedy way for stating website but closer solutions need more space 
-       BLMember youtube_video = BLMember(/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));
+       var youtube_video = BLMember(/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, _("Youtube Video"));
     // "
     // Explaination for link: Regex for [Something](Something). As greedy as editor on markdown
-       BLMember link = BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, _("Link"));
+       var link = BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, _("Link"));
        
     //  \[\^\d+\]:? leads to e.g. [^32], [^68]:   
        Regex_complex_commands = {BLMember (/<break>/, ""), BLMember (/<highlight>/, ""), BLMember (/<color #[\da-zA-Z]{6}>/, ""), BLMember (/\[\^\d+\]:?/, ""), youtube_video, link};

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -222,7 +222,7 @@ public class ENotes.PageTable : DatabaseTable {
     //private const string[] SYMBOLS_BLACKLIST = {"#", "`", "\t", "<br>", ">", "<", "\n", "~" };
     
     
-    // Describs member of BlackList. reg is the regular expression and replace the string it will be replaced
+    // Describs member of BlackList used in cleanup. reg is the regular expression and replace the string it will be replaced
     private struct BLMember {
         public GLib.Regex reg;
         public string replace;
@@ -242,15 +242,20 @@ public class ENotes.PageTable : DatabaseTable {
        BLMember[] Regex_complex_commands;
        
        
-       Regex_complex_commands = {BLMember (/<break>/, ""), BLMember (/<highlight>/, ""), BLMember (/<color #[\da-zA-Z]{6}>/, "")};
+    // [a-zA-Z0-9_\.\?\/:\=\+&\-'"]* is very greedy way for stating website but closer solutions need more space 
+       BLMember youtube_video = BLMember(/<youtube [a-zA-Z0-9_\.\?\/:\=\+&\-'"]*>/, "Youtube Video");
+    // "
+    // Explaination for link: Regex for [Something](Something). As greedy as editor
+       BLMember link = BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, "Link");
+       
+    //  \[\^\d+\]:? leads to e.g. [^32], [^68]:   
+       Regex_complex_commands = {BLMember (/<break>/, ""), BLMember (/<highlight>/, ""), BLMember (/<color #[\da-zA-Z]{6}>/, ""), BLMember (/\[\^\d+\]:?/, ""), youtube_video, link};
        
        
-    
     
     
     // Regex_Simple_elements used for symbols. Some symbols are part of more complex commands so these
     // list is used at the end
-    // One element of REGEX_BLACKLIST has regular expression and then string to replace it
     // first element replaces # ~ ` etc. with one regular expression 
         BLMember[] Regex_Simple_elements = {BLMember (/[#\n\t<>]+/, ""), BLMember(/<br>/, "")};
        

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -89,7 +89,7 @@ public class ENotes.PageTable : DatabaseTable {
         /// @translator this code summarises a notebook page. Instead of given youtube link this code changes into Youtube Video      
     
         // Explaination for link: Regex for [Something](Something). As greedy as editor on markdown
-        var link = new BLMember(/\[[a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, _("Link"));
+        var link = new BLMember(/\[[a-zA-Z0-9_ \.\?\/:\=\+&\-'"]*\]\([a-zA-Z0-9_\.\?\/:\=\+&\-'"]*\)/, "");
        
         //  \[\^\d+\]:? leads to e.g. [^32], [^68]: 
         var anchor = new BLMember (/\[\^\d+\]:?/, "");


### PR DESCRIPTION
This pull request intends to get a better summary for pages. Input like "<break>" or "<youtube https://www.youtube.com/watch?v=JI0rT3qHMOY>"wasn't handled in the right way as summary was "break" and "youtube https..".

Instead of simply replacing symbols regular expressions are used now.

But I am unsatisfied with the solutions as list are fixed so a new plugin has to be hardcoded. If wished I can change the plugin system so every plugin provide its own list of regular expressions and its replacement.