### PR TITLE
Minus Button sensitivity depends on row items

### DIFF
--- a/src/Widgets/PagesList.vala
+++ b/src/Widgets/PagesList.vala
@@ -272,11 +272,35 @@ public class ENotes.PagesList : Gtk.Box {
             refresh ();
         });
 
-        listbox.row_selected.connect ((row) => {
-            if (row == null || loading_pages) return;
-            minus_button.set_sensitive (true);
-            ENotes.ViewEditStack.get_instance ().set_page (((ENotes.PageItem) row).page, false);
-        });
+        listbox.row_selected.connect ((last_selected_row) => {
+             if (last_selected_row == null || loading_pages) return;
+                    
+             var rows = listbox.get_selected_rows ();
+                    
+             bool all_trashed = true;
+             bool all_not_trashed = true;
+                    
+             foreach (var row in rows) {
+                 var pagerow = ((ENotes.PageItem) row).page;
+                 var page_trashed = Trash.get_instance ().is_page_trashed (pagerow);
+                        
+                 all_trashed = all_trashed && page_trashed;
+                 all_not_trashed = all_not_trashed && !page_trashed;
+             }
+             if (all_not_trashed) {
+                 minus_button.set_sensitive (true);
+                        
+             }
+             else if (all_trashed) {
+                  minus_button.set_sensitive (true);
+                        
+             }
+             else {
+                 minus_button.set_sensitive (false);
+             }
+                    
+             ENotes.ViewEditStack.get_instance ().set_page (((ENotes.PageItem) last_selected_row).page, false);
+         });
 
         listbox.row_activated.connect ((row) => {
             window.toggle_edit ();

--- a/src/Widgets/PagesList.vala
+++ b/src/Widgets/PagesList.vala
@@ -288,8 +288,7 @@ public class ENotes.PagesList : Gtk.Box {
                  all_not_trashed = all_not_trashed && !page_trashed;
              }
              if (all_not_trashed) {
-                 minus_button.set_sensitive (true);
-                        
+                 minus_button.set_sensitive (true);                 
              }
              else {
                  minus_button.set_sensitive (false);

--- a/src/Widgets/PagesList.vala
+++ b/src/Widgets/PagesList.vala
@@ -30,9 +30,6 @@ public class ENotes.PagesList : Gtk.Box {
     private Gtk.Button plus_button;
     private Gtk.Label notebook_name;
     private Gtk.Label page_total;
-    
-    private Gtk.PixBuf delete_icon;
-    private Gtk.PixBuf undo_icon;
 
     public ENotes.Notebook current_notebook;
 
@@ -107,10 +104,6 @@ public class ENotes.PagesList : Gtk.Box {
         notebook_name = new Gtk.Label ("");
         page_total = new Gtk.Label ("");
         separator = new Gtk.Separator (Gtk.Orientation.VERTICAL);
-        
-        var icon_theme = Gtk.IconTheme.get_default ();
-        delete_icon = icon_theme.load_icon ("edit-delete-symbolic", 16, 0);
-        undo_icon = icon_theme.load_icon ("edit-undo-symbolic", 16, 0);
 
         minus_button.get_style_context ().add_class ("flat");
         plus_button.get_style_context ().add_class ("flat");
@@ -296,10 +289,6 @@ public class ENotes.PagesList : Gtk.Box {
              }
              if (all_not_trashed) {
                  minus_button.set_sensitive (true);
-                        
-             }
-             else if (all_trashed) {
-                  minus_button.set_sensitive (true);
                         
              }
              else {

--- a/src/Widgets/PagesList.vala
+++ b/src/Widgets/PagesList.vala
@@ -30,6 +30,9 @@ public class ENotes.PagesList : Gtk.Box {
     private Gtk.Button plus_button;
     private Gtk.Label notebook_name;
     private Gtk.Label page_total;
+    
+    private Gtk.PixBuf delete_icon;
+    private Gtk.PixBuf undo_icon;
 
     public ENotes.Notebook current_notebook;
 
@@ -104,6 +107,10 @@ public class ENotes.PagesList : Gtk.Box {
         notebook_name = new Gtk.Label ("");
         page_total = new Gtk.Label ("");
         separator = new Gtk.Separator (Gtk.Orientation.VERTICAL);
+        
+        var icon_theme = Gtk.IconTheme.get_default ();
+        delete_icon = icon_theme.load_icon ("edit-delete-symbolic", 16, 0);
+        undo_icon = icon_theme.load_icon ("edit-undo-symbolic", 16, 0);
 
         minus_button.get_style_context ().add_class ("flat");
         plus_button.get_style_context ().add_class ("flat");


### PR DESCRIPTION
behaviour now: minus button is sensitive except after you put an item into trash.
Behaviour after pull request: if all items arent trashed than you can click the button.

The intention is in a following pull request: the icon changes depending if you select items in the trash or not. If you selected items only in the trash icon of minus button changes and now you can put items out of the trash.

The following request would need a dependency on PixBuf. Is it ok then to add a new dependency?