### PR TITLE
Fix:cancel a pdf export dialog create a file

### DIFF
--- a/src/Services/FileManager.vala
+++ b/src/Services/FileManager.vala
@@ -138,6 +138,10 @@ public class ENotes.FileManager : Object {
             file = File.new_for_path (file_path);
         }
 
+        if (file == null) {
+          return null;
+        }
+
         try { // TODO: we have to write an empty file so we can get file path
             write_file (file, "");
         } catch (Error e) {


### PR DESCRIPTION
Fix the #187 issue. With this fix, the cancel button of export pdf dialog do nothing because the function is leave with null instead of write a pdf file with a default name. 