### PR TITLE
Word wrapping enhancements

### DIFF
--- a/src/Services/WordWrapper.vala
+++ b/src/Services/WordWrapper.vala
@@ -38,7 +38,7 @@ public class WordWrapper : Object {
      * Wraps this instance's text with first and second halves.
      * Unwraps this instance's text element if already wrapped with first and second halves.
      */
-     public static string apply_wrap (string original_text, string first_half, string second_half) {
+     public static string get_wrapped_text (string original_text, string first_half, string second_half) {
         string leading_spaces = "";
         string trailing_spaces = "";
 

--- a/src/Widgets/ToolbarButton.vala
+++ b/src/Widgets/ToolbarButton.vala
@@ -101,6 +101,7 @@ public class ENotes.ToolbarButton : Gtk.Button {
                 } else {
                     Gtk.TextIter cursor_position;
                     code_buffer.get_iter_at_offset (out cursor_position, code_buffer.cursor_position);
+                    
                     if (cursor_position.inside_word () || cursor_position.ends_word ()) {
                         // gets word the cursor is currently on and modify it
                         start = end = cursor_position;
@@ -131,8 +132,7 @@ public class ENotes.ToolbarButton : Gtk.Button {
     /**
      * Adjusts iterators to surround a word and its wrapper, if there is one
      */
-    private static void identify_word (ref Gtk.TextIter start, ref Gtk.TextIter end, 
-            string first_half, string second_half) {
+    private static void identify_word (ref Gtk.TextIter start, ref Gtk.TextIter end, string first_half, string second_half) {
             if (!start.starts_word ()) {
                 start.backward_word_start () ;
             }
@@ -146,18 +146,18 @@ public class ENotes.ToolbarButton : Gtk.Button {
     }
 
     /**
-     * checks if a text iterator starts after parameter text
+     * Checks if a text iterator starts after parameter text
      */
-    private static bool iter_starts_after(Gtk.TextIter iter, string text) {
+    private static bool iter_starts_after (Gtk.TextIter iter, string text) {
         Gtk.TextIter peek_surroundings = iter;
         peek_surroundings.backward_chars (text.length);
         return peek_surroundings.get_text (iter) == text;
     }
 
     /**
-     * checks if a text iterator is followed by parameter text
+     * Checks if a text iterator is followed by parameter text
      */
-    private static bool iter_is_followed_by(Gtk.TextIter iter, string text) {
+    private static bool iter_is_followed_by (Gtk.TextIter iter, string text) {
         Gtk.TextIter peek_surroundings = iter;
         peek_surroundings.forward_chars (text.length);
         return peek_surroundings.get_text (iter) == text;

--- a/src/Widgets/ToolbarButton.vala
+++ b/src/Widgets/ToolbarButton.vala
@@ -101,7 +101,7 @@ public class ENotes.ToolbarButton : Gtk.Button {
                 } else {
                     Gtk.TextIter cursor_position;
                     code_buffer.get_iter_at_offset (out cursor_position, code_buffer.cursor_position);
-                    
+
                     if (cursor_position.inside_word () || cursor_position.ends_word ()) {
                         // gets word the cursor is currently on and modify it
                         start = end = cursor_position;

--- a/src/Widgets/ToolbarButton.vala
+++ b/src/Widgets/ToolbarButton.vala
@@ -77,10 +77,10 @@ public class ENotes.ToolbarButton : Gtk.Button {
         clicked.connect (() => {
             Gtk.TextIter start, end;
             code_buffer.get_selection_bounds (out start, out end);
-            
+
             if (code_buffer.has_selection) {
-                var text = start.get_text (end).strip ();
-                
+                var text = start.get_text (end);
+
                 if (this.type == 2) {
                     plugin.request_string (text);
                 } else {
@@ -89,7 +89,7 @@ public class ENotes.ToolbarButton : Gtk.Button {
                         int trailing_begin = first_half.char_count ();
                         int trailing_end = text.char_count () - second_half.char_count ();
                         text = text.substring (trailing_begin, trailing_end - trailing_begin);
-                        code_buffer.@delete(ref start, ref end);
+                        code_buffer.@delete (ref start, ref end);
                         code_buffer.insert_at_cursor (text, -1);
                     } else {
                         // adds first and second halves
@@ -122,7 +122,7 @@ public class ENotes.ToolbarButton : Gtk.Button {
         });
     }
 
-    private bool already_applied (string text, string first_half, string second_half) {
+    private static bool already_applied (string text, string first_half, string second_half) {
         return text.has_prefix (first_half) && text.has_suffix (second_half);
     }
 }

--- a/src/Widgets/ToolbarButton.vala
+++ b/src/Widgets/ToolbarButton.vala
@@ -83,11 +83,9 @@ public class ENotes.ToolbarButton : Gtk.Button {
                 if (this.type == 2) {
                     plugin.request_string (text);
                 } else {
-                    var changed_text = WordWrapper.apply_wrap (text, first_half, second_half);
-                    code_buffer.@delete (ref start, ref end);
-                    code_buffer.insert_at_cursor (changed_text, -1);
+                    var wrapped_text = WordWrapper.get_wrapped_text (text, first_half, second_half);
+                    changes_text (ref code_buffer, start, end, wrapped_text);
                 }
-
             } else {
                 if (this.type == 1) {
                     var file = FileManager.get_file_from_user (false);
@@ -101,15 +99,67 @@ public class ENotes.ToolbarButton : Gtk.Button {
                 } else if (type == 2) {
                     plugin.request_string ("");
                 } else {
-                    code_buffer.insert_at_cursor (first_half, -1);
-                    int end_first_half_pos = code_buffer.cursor_position;
-                    code_buffer.insert_at_cursor (second_half, -1);
-
                     Gtk.TextIter cursor_position;
-                    code_buffer.get_iter_at_offset (out cursor_position, end_first_half_pos);
-                    code_buffer.place_cursor (cursor_position);
+                    code_buffer.get_iter_at_offset (out cursor_position, code_buffer.cursor_position);
+                    if (cursor_position.inside_word () || cursor_position.ends_word ()) {
+                        // gets word the cursor is currently on and modify it
+                        start = end = cursor_position;
+                        identify_word (ref start, ref end, first_half, second_half);
+                        var text = start.get_text (end);
+                        var wrapped_text = WordWrapper.get_wrapped_text (text, first_half, second_half);
+                        changes_text (ref code_buffer, start, end, wrapped_text);
+                    } else {
+                        // prints the wrapping text and put cursor in the middle 
+                        code_buffer.insert_at_cursor (first_half + second_half, -1);
+                        code_buffer.get_iter_at_offset (out cursor_position, code_buffer.cursor_position);
+                        cursor_position.backward_chars (second_half.length);
+                        code_buffer.place_cursor (cursor_position);
+                    }
                 }
             }
         });
+    }
+
+    /**
+     * Replaces the content from  iter start to iter end with the informed text
+     */
+    private void changes_text (ref Gtk.SourceBuffer buffer, Gtk.TextIter start, Gtk.TextIter end, string text) {
+        code_buffer.@delete (ref start, ref end);
+        code_buffer.insert_at_cursor (text, -1);
+    }
+
+    /**
+     * Adjusts iterators to surround a word and its wrapper, if there is one
+     */
+    private static void identify_word (ref Gtk.TextIter start, ref Gtk.TextIter end, 
+            string first_half, string second_half) {
+            if (!start.starts_word ()) {
+                start.backward_word_start () ;
+            }
+            if (!end.ends_word ()) {
+                end.forward_word_end ();
+            }
+            if (iter_starts_after (start, first_half) && iter_is_followed_by (end, second_half)) {
+                start.backward_chars (first_half.length);
+                end.forward_chars (second_half.length);
+            }
+    }
+
+    /**
+     * checks if a text iterator starts after parameter text
+     */
+    private static bool iter_starts_after(Gtk.TextIter iter, string text) {
+        Gtk.TextIter peek_surroundings = iter;
+        peek_surroundings.backward_chars (text.length);
+        return peek_surroundings.get_text (iter) == text;
+    }
+
+    /**
+     * checks if a text iterator is followed by parameter text
+     */
+    private static bool iter_is_followed_by(Gtk.TextIter iter, string text) {
+        Gtk.TextIter peek_surroundings = iter;
+        peek_surroundings.forward_chars (text.length);
+        return peek_surroundings.get_text (iter) == text;
     }
 }


### PR DESCRIPTION
Fixes #199

Changes made in this pull request: 
- When going to wrap a word to make it bold, italic or strike-through and there is no selection, detects if cursor is inside of word and applies it to the word

I guess this finishes the wash up for this whole word wrapping thing :) it functions as expected. If you have any observations just let me know Philip. We might change the whole word-edge detection thing to a whole new utility class just like we did on `WordWrapper`. 