### PR TITLE
wraps or unwraps word if cursor in the middle of it

### DIFF
--- a/src/Services/WordWrapper.vala
+++ b/src/Services/WordWrapper.vala
@@ -116,7 +116,7 @@ public class WordWrapper : Object {
      */
     private static void detects_wrapping (ref Gtk.TextIter start, ref Gtk.TextIter end, string first_half, string second_half) {
         if (opens_wrapping (start, first_half, second_half)) {
-            backwards_iter_to_whitespace (ref start, first_half.length);
+            forwards_iter_until_whitespace (ref start, first_half.length);
             end = start;
             end.forward_visible_word_end ();
             end.forward_chars (second_half.length) ;
@@ -129,16 +129,16 @@ public class WordWrapper : Object {
     }
 
     /**
-     * Detects if current word pointed by iter is surrounded by first and second halves
+     * Detects if current word pointed by iter is an opening tag that wraps a word
      */
     private static bool opens_wrapping (Gtk.TextIter iter, string first_half, string second_half) {
-        backwards_iter_to_whitespace (ref iter, first_half.length);
+        forwards_iter_until_whitespace (ref iter, first_half.length);
         return (iter_is_followed_by (iter, first_half) && word_ends_with (iter, second_half));
     }
 
 
     /**
-     * Detects if current word pointed by iter is surrounded by first and second halves
+     * Detects if current word pointed by iter is a closing tag that wraps a word
      */
     private static bool closes_wrapping (Gtk.TextIter iter, string first_half, string second_half) {
         forwards_iter_to_whitespace (ref iter, second_half.length);
@@ -148,7 +148,7 @@ public class WordWrapper : Object {
     /**
      * Backwards an iterator up to n times searching for a whitespace
      */
-    private static void backwards_iter_to_whitespace (ref Gtk.TextIter iter, int n ) {
+    private static void forwards_iter_until_whitespace (ref Gtk.TextIter iter, int n ) {
         Gtk.TextIter search_limit = iter;
         search_limit.backward_chars (n + 1);
         iter.backward_find_char ((c) => {

--- a/src/Services/WordWrapper.vala
+++ b/src/Services/WordWrapper.vala
@@ -93,6 +93,9 @@ public class WordWrapper : Object {
         }
     }
 
+    /**
+     * Detects if iterators' pointed text is surrounded by first and second halves
+     */
     private static void detect_surroundings (ref Gtk.TextIter start, ref Gtk.TextIter end, string first_half, string second_half) {
         if (iter_starts_after (start, first_half) && iter_is_followed_by (end, second_half)) {
             start.backward_chars (first_half.length);

--- a/src/Services/WordWrapper.vala
+++ b/src/Services/WordWrapper.vala
@@ -40,8 +40,7 @@ public class WordWrapper : Object {
      * Retuns the found string.
      */
     public static string identify_word (ref Gtk.TextIter start, ref Gtk.TextIter end, string first_half, string second_half) {
-        detect_word_edges (ref start, ref end);
-        detect_surroundings (ref start, ref end, first_half, second_half);
+        detect_edges (ref start, ref end, first_half, second_half);
         return start.get_text (end);
     }
 
@@ -72,7 +71,7 @@ public class WordWrapper : Object {
      * Returns the given stripped string with its leading and trailing whitespaces back on
      */
     private static string get_return_string (string text, string leading_spaces, string trailing_spaces) {
-        return leading_spaces.concat(text).concat(trailing_spaces);
+        return leading_spaces.concat (text).concat (trailing_spaces);
     }
 
     /**
@@ -92,27 +91,103 @@ public class WordWrapper : Object {
             trailing_spaces = match_info.fetch (0);
         }
     }
+    
+    /**
+     * Adjusts iterators to surround a word or its wrappers if present
+     */
+    private static void detect_edges (ref Gtk.TextIter start, ref Gtk.TextIter end, string first_half, string second_half) {
+        if (no_edges (end)) {
+            return;
+        }
+        if (start.get_char ().isalnum () || end.get_char ().isspace () || end.ends_line ()) {
+            // moves iter start to beggining of word and iter end to ending of word
+            if (!start.starts_word ()) {
+                start.backward_word_start ();
+            }
+            if (!end.ends_word ()) {
+                end.forward_word_end ();
+            }
+        }
+        detects_wrapping (ref start, ref end, first_half, second_half);
+    }
 
     /**
      * Detects if iterators' pointed text is surrounded by first and second halves
      */
-    private static void detect_surroundings (ref Gtk.TextIter start, ref Gtk.TextIter end, string first_half, string second_half) {
-        if (iter_starts_after (start, first_half) && iter_is_followed_by (end, second_half)) {
-            start.backward_chars (first_half.length);
-            end.forward_chars (second_half.length);
+    private static void detects_wrapping (ref Gtk.TextIter start, ref Gtk.TextIter end, string first_half, string second_half) {
+        if (opens_wrapping (start, first_half, second_half)) {
+            backwards_iter_to_whitespace (ref start, first_half.length);
+            end = start;
+            end.forward_visible_word_end ();
+            end.forward_chars (second_half.length) ;
+        } else if (closes_wrapping (end, first_half, second_half)) {
+            forwards_iter_to_whitespace (ref end, second_half.length);
+            start = end;
+            start.backward_visible_word_start ();
+            start.backward_chars (first_half.length) ;
         }
     }
 
     /**
-     * Adjusts iterators to surround a word
+     * Detects if current word pointed by iter is surrounded by first and second halves
      */
-    private static void detect_word_edges (ref Gtk.TextIter start, ref Gtk.TextIter end) {
-        if (!start.starts_word ()) {
-            start.backward_word_start ();
+    private static bool opens_wrapping (Gtk.TextIter iter, string first_half, string second_half) {
+        backwards_iter_to_whitespace (ref iter, first_half.length);
+        return (iter_is_followed_by (iter, first_half) && word_ends_with (iter, second_half));
+    }
+
+
+    /**
+     * Detects if current word pointed by iter is surrounded by first and second halves
+     */
+    private static bool closes_wrapping (Gtk.TextIter iter, string first_half, string second_half) {
+        forwards_iter_to_whitespace (ref iter, second_half.length);
+        return (iter_starts_after (iter, second_half) && word_starts_with (iter, first_half));
+    }
+
+    /**
+     * Backwards an iterator up to n times searching for a whitespace
+     */
+    private static void backwards_iter_to_whitespace (ref Gtk.TextIter iter, int n ) {
+        Gtk.TextIter search_limit = iter;
+        search_limit.backward_chars (n + 1);
+        iter.backward_find_char ((c) => {
+            return c.isspace ();
+        }, search_limit);
+        if (iter.get_char ().isspace ()) {
+            iter.forward_char ();
         }
-        if (!end.ends_word ()) {
-            end.forward_word_end ();
-        }
+    }
+
+    /**
+     * Forwards an iterator up to n times searching for a whitespace
+     */
+    private static void forwards_iter_to_whitespace (ref Gtk.TextIter iter, int n) {
+        Gtk.TextIter search_limit = iter;
+        search_limit.forward_chars (n + 1);
+        iter.forward_find_char ((c) => {
+            return c.isspace ();
+        }, search_limit);
+    }
+
+    /**
+     * Detects if the word pointed by the iterator is prefixed with tag
+     */
+    private static bool word_ends_with (Gtk.TextIter iter, string tag) {
+        iter.forward_visible_word_end ();
+        Gtk.TextIter helper = iter;
+        helper.forward_chars (tag.length);
+        return iter.get_text (helper) == tag;
+    }
+
+    /**
+     * Detects if the word pointed by the iterator is prefixed with tag
+     */
+    private static bool word_starts_with (Gtk.TextIter iter, string tag) {
+        iter.backward_visible_word_start ();
+        Gtk.TextIter helper = iter;
+        helper.backward_chars (tag.length);
+        return helper.get_text (iter) == tag;
     }
 
     /**
@@ -131,6 +206,16 @@ public class WordWrapper : Object {
         Gtk.TextIter peek_surroundings = iter;
         peek_surroundings.forward_chars (text.length);
         return peek_surroundings.get_text (iter) == text;
+    }
+
+
+    /**
+     * Detects if iter is in between two whitespaces
+     */
+    private static bool no_edges (Gtk.TextIter iter) {
+        bool previous_value = iter.get_char ().isspace ();
+        iter.backward_char ();
+        return iter.get_char ().isspace () && previous_value && true;
     }
 
     private static bool already_wrapped (string text, string first_half, string second_half) {

--- a/src/Services/WordWrapper.vala
+++ b/src/Services/WordWrapper.vala
@@ -35,10 +35,21 @@ public class WordWrapper : Object {
     }
 
     /**
+     * Moves start and end iterators to the beggining and end of an word, respectively, additionaly
+     * with its wrappers, if present.
+     * Retuns the found string.
+     */
+    public static string identify_word (ref Gtk.TextIter start, ref Gtk.TextIter end, string first_half, string second_half) {
+        detect_word_edges (ref start, ref end);
+        detect_surroundings (ref start, ref end, first_half, second_half);
+        return start.get_text (end);
+    }
+
+    /**
      * Wraps this instance's text with first and second halves.
      * Unwraps this instance's text element if already wrapped with first and second halves.
      */
-     public static string get_wrapped_text (string original_text, string first_half, string second_half) {
+     public static string wrap_string (string original_text, string first_half, string second_half) {
         string leading_spaces = "";
         string trailing_spaces = "";
 
@@ -80,6 +91,43 @@ public class WordWrapper : Object {
         if (match_info.matches ()) {
             trailing_spaces = match_info.fetch (0);
         }
+    }
+
+    private static void detect_surroundings (ref Gtk.TextIter start, ref Gtk.TextIter end, string first_half, string second_half) {
+        if (iter_starts_after (start, first_half) && iter_is_followed_by (end, second_half)) {
+            start.backward_chars (first_half.length);
+            end.forward_chars (second_half.length);
+        }
+    }
+
+    /**
+     * Adjusts iterators to surround a word
+     */
+    private static void detect_word_edges (ref Gtk.TextIter start, ref Gtk.TextIter end) {
+        if (!start.starts_word ()) {
+            start.backward_word_start ();
+        }
+        if (!end.ends_word ()) {
+            end.forward_word_end ();
+        }
+    }
+
+    /**
+     * Checks if a text iterator starts after parameter text
+     */
+    private static bool iter_starts_after (Gtk.TextIter iter, string text) {
+        Gtk.TextIter peek_surroundings = iter;
+        peek_surroundings.backward_chars (text.length);
+        return peek_surroundings.get_text (iter) == text;
+    }
+
+    /**
+     * Checks if a text iterator is followed by parameter text
+     */
+    private static bool iter_is_followed_by (Gtk.TextIter iter, string text) {
+        Gtk.TextIter peek_surroundings = iter;
+        peek_surroundings.forward_chars (text.length);
+        return peek_surroundings.get_text (iter) == text;
     }
 
     private static bool already_wrapped (string text, string first_half, string second_half) {

--- a/src/Services/WordWrapper.vala
+++ b/src/Services/WordWrapper.vala
@@ -175,9 +175,7 @@ public class WordWrapper : Object {
      */
     private static bool word_ends_with (Gtk.TextIter iter, string tag) {
         iter.forward_visible_word_end ();
-        Gtk.TextIter helper = iter;
-        helper.forward_chars (tag.length);
-        return iter.get_text (helper) == tag;
+        return iter_is_followed_by(iter, tag);
     }
 
     /**
@@ -185,9 +183,7 @@ public class WordWrapper : Object {
      */
     private static bool word_starts_with (Gtk.TextIter iter, string tag) {
         iter.backward_visible_word_start ();
-        Gtk.TextIter helper = iter;
-        helper.backward_chars (tag.length);
-        return helper.get_text (iter) == tag;
+        return iter_starts_after(iter, tag);
     }
 
     /**

--- a/src/Services/WordWrapper.vala
+++ b/src/Services/WordWrapper.vala
@@ -38,7 +38,7 @@ public class WordWrapper : Object {
      * Wraps this instance's text with first and second halves.
      * Unwraps this instance's text element if already wrapped with first and second halves.
      */
-     public static string apply_wrap (string original_text, string first_half, string second_half) {
+     public static string get_wrapped_text (string original_text, string first_half, string second_half) {
         string leading_spaces = "";
         string trailing_spaces = "";
 

--- a/src/Widgets/ToolbarButton.vala
+++ b/src/Widgets/ToolbarButton.vala
@@ -102,7 +102,7 @@ public class ENotes.ToolbarButton : Gtk.Button {
                     Gtk.TextIter cursor_position;
                     code_buffer.get_iter_at_offset (out cursor_position, code_buffer.cursor_position);
 
-                    if (is_cursor_inside_word (cursor_position)) {
+                    if (is_cursor_inside_word (cursor_position, first_half, second_half)) {
                         // gets word the cursor is currently on and modify it
                         start = end = cursor_position;
                         var word = WordWrapper.identify_word (ref start, ref end, first_half, second_half);
@@ -123,8 +123,11 @@ public class ENotes.ToolbarButton : Gtk.Button {
     /**
      * Detects if cursor is inside a word
      */
-    private bool is_cursor_inside_word (Gtk.TextIter cursor_position) {
-        return cursor_position.inside_word () || cursor_position.ends_word ();
+    private bool is_cursor_inside_word (Gtk.TextIter cursor_position, string first_half, string second_half) {
+        return cursor_position.inside_word () || 
+                cursor_position.get_char ().isspace () || 
+                cursor_position.get_char ().to_string () in first_half ||
+                cursor_position.get_char ().to_string () in second_half;
     }
 
     /**

--- a/src/Widgets/ToolbarButton.vala
+++ b/src/Widgets/ToolbarButton.vala
@@ -83,8 +83,8 @@ public class ENotes.ToolbarButton : Gtk.Button {
                 if (this.type == 2) {
                     plugin.request_string (text);
                 } else {
-                    var wrapped_text = WordWrapper.get_wrapped_text (text, first_half, second_half);
-                    changes_text (ref code_buffer, start, end, wrapped_text);
+                    var wrapped_text = WordWrapper.wrap_string (text, first_half, second_half);
+                    this.change_text (start, end, wrapped_text);
                 }
             } else {
                 if (this.type == 1) {
@@ -102,13 +102,12 @@ public class ENotes.ToolbarButton : Gtk.Button {
                     Gtk.TextIter cursor_position;
                     code_buffer.get_iter_at_offset (out cursor_position, code_buffer.cursor_position);
 
-                    if (cursor_position.inside_word () || cursor_position.ends_word ()) {
+                    if (cursor_inside_word (cursor_position)) {
                         // gets word the cursor is currently on and modify it
                         start = end = cursor_position;
-                        identify_word (ref start, ref end, first_half, second_half);
-                        var text = start.get_text (end);
-                        var wrapped_text = WordWrapper.get_wrapped_text (text, first_half, second_half);
-                        changes_text (ref code_buffer, start, end, wrapped_text);
+                        var word = WordWrapper.identify_word (ref start, ref end, first_half, second_half);
+                        var wrapped_text = WordWrapper.wrap_string (word, first_half, second_half);
+                        this.change_text (start, end, wrapped_text);
                     } else {
                         // prints the wrapping text and put cursor in the middle 
                         code_buffer.insert_at_cursor (first_half + second_half, -1);
@@ -122,44 +121,17 @@ public class ENotes.ToolbarButton : Gtk.Button {
     }
 
     /**
+     * Detects if cursor is inside a word
+     */
+    private bool cursor_inside_word (Gtk.TextIter cursor_position) {
+        return cursor_position.inside_word () || cursor_position.ends_word ();
+    }
+
+    /**
      * Replaces the content from  iter start to iter end with the informed text
      */
-    private void changes_text (ref Gtk.SourceBuffer buffer, Gtk.TextIter start, Gtk.TextIter end, string text) {
+    private void change_text (Gtk.TextIter start, Gtk.TextIter end, string text) {
         code_buffer.@delete (ref start, ref end);
         code_buffer.insert_at_cursor (text, -1);
-    }
-
-    /**
-     * Adjusts iterators to surround a word and its wrapper, if there is one
-     */
-    private static void identify_word (ref Gtk.TextIter start, ref Gtk.TextIter end, string first_half, string second_half) {
-            if (!start.starts_word ()) {
-                start.backward_word_start () ;
-            }
-            if (!end.ends_word ()) {
-                end.forward_word_end ();
-            }
-            if (iter_starts_after (start, first_half) && iter_is_followed_by (end, second_half)) {
-                start.backward_chars (first_half.length);
-                end.forward_chars (second_half.length);
-            }
-    }
-
-    /**
-     * Checks if a text iterator starts after parameter text
-     */
-    private static bool iter_starts_after (Gtk.TextIter iter, string text) {
-        Gtk.TextIter peek_surroundings = iter;
-        peek_surroundings.backward_chars (text.length);
-        return peek_surroundings.get_text (iter) == text;
-    }
-
-    /**
-     * Checks if a text iterator is followed by parameter text
-     */
-    private static bool iter_is_followed_by (Gtk.TextIter iter, string text) {
-        Gtk.TextIter peek_surroundings = iter;
-        peek_surroundings.forward_chars (text.length);
-        return peek_surroundings.get_text (iter) == text;
     }
 }

--- a/src/Widgets/ToolbarButton.vala
+++ b/src/Widgets/ToolbarButton.vala
@@ -102,7 +102,7 @@ public class ENotes.ToolbarButton : Gtk.Button {
                     Gtk.TextIter cursor_position;
                     code_buffer.get_iter_at_offset (out cursor_position, code_buffer.cursor_position);
 
-                    if (cursor_inside_word (cursor_position)) {
+                    if (is_cursor_inside_word (cursor_position)) {
                         // gets word the cursor is currently on and modify it
                         start = end = cursor_position;
                         var word = WordWrapper.identify_word (ref start, ref end, first_half, second_half);
@@ -123,7 +123,7 @@ public class ENotes.ToolbarButton : Gtk.Button {
     /**
      * Detects if cursor is inside a word
      */
-    private bool cursor_inside_word (Gtk.TextIter cursor_position) {
+    private bool is_cursor_inside_word (Gtk.TextIter cursor_position) {
         return cursor_position.inside_word () || cursor_position.ends_word ();
     }
 

--- a/src/Widgets/ToolbarButton.vala
+++ b/src/Widgets/ToolbarButton.vala
@@ -83,9 +83,8 @@ public class ENotes.ToolbarButton : Gtk.Button {
                 if (this.type == 2) {
                     plugin.request_string (text);
                 } else {
-                    var changed_text = WordWrapper.apply_wrap (text, first_half, second_half);
-                    code_buffer.@delete (ref start, ref end);
-                    code_buffer.insert_at_cursor (changed_text, -1);
+                    var wrapped_text = WordWrapper.get_wrapped_text (text, first_half, second_half);
+                    changes_text (ref code_buffer, start, end, wrapped_text);
                 }
             } else {
                 if (this.type == 1) {
@@ -100,15 +99,67 @@ public class ENotes.ToolbarButton : Gtk.Button {
                 } else if (type == 2) {
                     plugin.request_string ("");
                 } else {
-                    code_buffer.insert_at_cursor (first_half, -1);
-                    int end_first_half_pos = code_buffer.cursor_position;
-                    code_buffer.insert_at_cursor (second_half, -1);
-
                     Gtk.TextIter cursor_position;
-                    code_buffer.get_iter_at_offset (out cursor_position, end_first_half_pos);
-                    code_buffer.place_cursor (cursor_position);
+                    code_buffer.get_iter_at_offset (out cursor_position, code_buffer.cursor_position);
+
+                    if (cursor_position.inside_word () || cursor_position.ends_word ()) {
+                        // gets word the cursor is currently on and modify it
+                        start = end = cursor_position;
+                        identify_word (ref start, ref end, first_half, second_half);
+                        var text = start.get_text (end);
+                        var wrapped_text = WordWrapper.get_wrapped_text (text, first_half, second_half);
+                        changes_text (ref code_buffer, start, end, wrapped_text);
+                    } else {
+                        // prints the wrapping text and put cursor in the middle 
+                        code_buffer.insert_at_cursor (first_half + second_half, -1);
+                        code_buffer.get_iter_at_offset (out cursor_position, code_buffer.cursor_position);
+                        cursor_position.backward_chars (second_half.length);
+                        code_buffer.place_cursor (cursor_position);
+                    }
                 }
             }
         });
+    }
+
+    /**
+     * Replaces the content from  iter start to iter end with the informed text
+     */
+    private void changes_text (ref Gtk.SourceBuffer buffer, Gtk.TextIter start, Gtk.TextIter end, string text) {
+        code_buffer.@delete (ref start, ref end);
+        code_buffer.insert_at_cursor (text, -1);
+    }
+
+    /**
+     * Adjusts iterators to surround a word and its wrapper, if there is one
+     */
+    private static void identify_word (ref Gtk.TextIter start, ref Gtk.TextIter end, string first_half, string second_half) {
+            if (!start.starts_word ()) {
+                start.backward_word_start () ;
+            }
+            if (!end.ends_word ()) {
+                end.forward_word_end ();
+            }
+            if (iter_starts_after (start, first_half) && iter_is_followed_by (end, second_half)) {
+                start.backward_chars (first_half.length);
+                end.forward_chars (second_half.length);
+            }
+    }
+
+    /**
+     * Checks if a text iterator starts after parameter text
+     */
+    private static bool iter_starts_after (Gtk.TextIter iter, string text) {
+        Gtk.TextIter peek_surroundings = iter;
+        peek_surroundings.backward_chars (text.length);
+        return peek_surroundings.get_text (iter) == text;
+    }
+
+    /**
+     * Checks if a text iterator is followed by parameter text
+     */
+    private static bool iter_is_followed_by (Gtk.TextIter iter, string text) {
+        Gtk.TextIter peek_surroundings = iter;
+        peek_surroundings.forward_chars (text.length);
+        return peek_surroundings.get_text (iter) == text;
     }
 }


### PR DESCRIPTION
Hallelujah

Fixes #199

Changes made in this pull request:

- When going to wrap a word to make it bold, italic or strike-through and there is no selection, detects if cursor is inside of word and applies it to the word

I guess this finishes the wash up for this whole word wrapping thing :) it functions as expected. If you have any observations just let me know Philip. We might change the whole word-edge detection thing to a whole new utility class just like we did on WordWrapper.