### PR TITLE
Added a sub category for the .desktop file

### DIFF
--- a/data/com.github.philip-scott.notes-up.desktop
+++ b/data/com.github.philip-scott.notes-up.desktop
@@ -9,4 +9,4 @@ Icon=com.github.philip-scott.notes-up
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=Office;
+Categories=Office;WordProcessor;


### PR DESCRIPTION
https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories#Office according to the FreeDesktop standards. Some Linux distributions are rather strict about it.

Indirectly fixes https://github.com/Philip-Scott/Notes-up/issues/236 as I will use this upstreamed patch instead of the RPM macro from now on.