### PR TITLE
Fix & re-add Japanese Translation

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -1,0 +1,461 @@
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# ryonakano <ryonakaknock@gmail.com>, 2018.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-07-09 13:07-0500\n"
+"PO-Revision-Date: 2018-03-21 20:12+0900\n"
+"Last-Translator: ryonakano <ryonakaknock@gmail.com>\n"
+"Language-Team: Japanese <kde-i18n-doc@kde.org>\n"
+"Language: ja_JP\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Lokalize 2.0\n"
+
+#: /home/felipe/Code/Notes-up/po/../src/Services/Page.vala:148
+#: /home/felipe/Code/Notes-up/po/../src/Services/Page.vala:212
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PagesList.vala:121
+msgid "New Page"
+msgstr "新しいページ"
+
+#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:150
+msgid "Print to File"
+msgstr "ファイルに印刷"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar.vala:25
+msgid "Notebooks"
+msgstr "ノート"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar.vala:26
+msgid "Bookmarks"
+msgstr "ブックマーク"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar.vala:27
+msgid "Trash"
+msgstr "ゴミ箱"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar.vala:110
+msgid "My First Notebook"
+msgstr "自分の最初のノート"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/NotebookItem.vala:48
+msgid "Edit Notebook"
+msgstr "ノートを編集"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/NotebookItem.vala:49
+msgid "New Section"
+msgstr "新しいセクション"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/NotebookItem.vala:50
+msgid "Delete Notebook"
+msgstr "ノートを削除"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Viewer.vala:23
+msgid "Default"
+msgstr "デフォルト"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Viewer.vala:23
+msgid "Air"
+msgstr "Air"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Viewer.vala:23
+msgid "Modest"
+msgstr "Modest"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:61
+msgid "View"
+msgstr "ビュー"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:62
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:81
+msgid "Edit"
+msgstr "編集"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:65
+msgid "Change mode"
+msgstr "モードを切り替え"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:83
+msgid "Search your current notebook"
+msgstr "現在のノートを検索"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:108
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:104
+msgid "New Notebook"
+msgstr "新しいノート"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:109
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:43
+msgid "Preferences"
+msgstr "設定"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:110
+msgid "Export to PDF"
+msgstr "PDF にエクスポート"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/BookmarkButton.vala:44
+msgid "Bookmark page"
+msgstr "ページをブックマーク"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:111
+msgid "Add bold to text"
+msgstr "テキストを太字にする"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:112
+msgid "Add italic to text"
+msgstr "テキストを斜体にする"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:113
+msgid "Strikethrough text"
+msgstr "テキストに打ち消し線を引く"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:115
+msgid "Insert a quote"
+msgstr "引用を挿入する"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:116
+msgid "Insert code"
+msgstr "コードを挿入する"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:117
+msgid "Insert a link"
+msgstr "リンクを挿入する"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:119
+msgid "Add a bulleted list"
+msgstr "箇条書きリストを追加する"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:120
+msgid "Add a Numbered list"
+msgstr "番号付きリストを追加する"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:122
+msgid "Insert an image"
+msgstr "画像を挿入する"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:159
+msgid "Formatting"
+msgstr "書式"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:51
+msgid "Editor"
+msgstr "エディター"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:52
+msgid "Viewer"
+msgstr "ビューアー"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:65
+msgid "_Close"
+msgstr "閉じる (_C)"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:73
+msgid "Font:"
+msgstr "フォント:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:83
+msgid "Theme:"
+msgstr "テーマ:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:108
+msgid "Automatic indentation:"
+msgstr "自動インデント:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:116
+msgid "Show line Numbers:"
+msgstr "行番号の表示:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:124
+msgid "Keep Sidebar Visible:"
+msgstr "サイドバーを表示する:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:152
+msgid "Global style modifications"
+msgstr "グローバルスタイルの変更"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:165
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:134
+msgid "Stylesheet:"
+msgstr "スタイルシート:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:62
+msgid "Name:"
+msgstr "名前:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:63
+msgid "Color:"
+msgstr "色:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:71
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:84
+msgid "Create"
+msgstr "作成"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:102
+msgid "Properties"
+msgstr "プロパティ"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:103
+msgid "Style"
+msgstr "スタイル"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:121
+msgid "Style modifications"
+msgstr "スタイルの変更"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/TrashItem.vala:28
+msgid "Restore"
+msgstr "元に戻す"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:41
+msgid "Large Header"
+msgstr "大見出し"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:42
+msgid "Medium Header"
+msgstr "中見出し"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:43
+msgid "Small Header"
+msgstr "小見出し"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:45
+msgid "<i>Italic</i>"
+msgstr "<i>斜体</i>"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:45
+msgid "_italic_"
+msgstr "_斜体_"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:46
+msgid "<b>Bold</b>"
+msgstr "<b>太字</b>"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:46
+msgid "**bold**"
+msgstr "**太字**"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:47
+msgid "<s>Strike</s>"
+msgstr "<s>打ち消し</s>"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:47
+msgid "~~strike~~"
+msgstr "~~打ち消し~~"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:48
+msgid "|  <i>quote</i>"
+msgstr "|  <i>引用</i>"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:50
+msgid "1. Numbered list"
+msgstr "1. 番号付きリスト"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:51
+msgid "⚫ Bulleted list"
+msgstr "⚫ 箇条書きリスト"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:53
+msgid "Divider"
+msgstr "水平線"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:54
+msgid "Code"
+msgstr "コード"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:55
+msgid "Code Block"
+msgstr "コードブロック"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:56
+msgid "Link"
+msgstr "リンク"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:56
+msgid "[Text](www...) "
+msgstr "[テキスト](www...)"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:57
+msgid "Citation Anchor"
+msgstr "引用アンカー"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:58
+msgid "Citation Text"
+msgstr "引用テキスト"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:60
+msgid "Youtube Video"
+msgstr "Youtube ビデオ"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:60
+msgid "<youtube [link]>"
+msgstr "<youtube [リンク]>"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:61
+msgid "Page Break (when exporting)"
+msgstr "ページ区切り (エクスポート時)"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:62
+msgid "Enable Syntax Highlighting"
+msgstr "シンタックスハイライトを有効化"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:63
+msgid "Set Color"
+msgstr "色を設定"
+
+#. //bugzilla.gnome.org/show_bug.cgi?id=758000 is fixed.
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PagesList.vala:201
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PagesList.vala:300
+#, c-format
+msgid "%i Page"
+msgid_plural "%i Pages"
+msgstr[0] "%i ページ"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/BookmarkItem.vala:54
+msgid "Remove"
+msgstr "削除"
+
+#. / These keys must be valid since they will be used across the app
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:36
+msgid "<Ctrl>M"
+msgstr "<Ctrl>M"
+
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:37
+msgid "<Ctrl>S"
+msgstr "<Ctrl>S"
+
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:38
+msgid "<Ctrl>Q"
+msgstr "<Ctrl>Q"
+
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:39
+msgid "<Ctrl><Shift>N"
+msgstr "<Ctrl><Shift>N"
+
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:40
+msgid "<Ctrl>F"
+msgstr "<Ctrl>F"
+
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:41
+msgid "<Ctrl>K"
+msgstr "<Ctrl>K"
+
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:42
+msgid "<Ctrl>B"
+msgstr "<Ctrl>B"
+
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:43
+msgid "<Ctrl>I"
+msgstr "<Ctrl>I"
+
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:44
+msgid "<Ctrl>T"
+msgstr "<Ctrl>T"
+
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:62
+msgid "Notes-Up"
+msgstr "Notes-up"
+
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:63
+msgid "Your Markdown Notebook."
+msgstr "自分だけのマークダウン形式のノート。"
+
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:64
+msgid "About Notes"
+msgstr "Notes について"
+
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:82
+msgid "translator-credits"
+msgstr "翻訳者のクレジット"
+
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Color.vala:35
+msgid ""
+"Set font color for the line with <color [#color]> or for some text with "
+"<color [color] [text]>"
+msgstr "行の色を <color [#色]> で設定するか、テキストの色を <color [color] [text]> で設定してください"
+
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Color.vala:39
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Color.vala:68
+msgid "Font color"
+msgstr "フォントの色"
+
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Youtube.vala:30
+msgid "Embed youtube videos: <youtube [video]>"
+msgstr "Youtube の動画の埋め込み: <Youtube [ビデオ]>"
+
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Youtube.vala:34
+msgid "Youtube"
+msgstr "Youtube"
+
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Youtube.vala:42
+msgid "Insert Youtube video"
+msgstr "Youtube ビデオを挿入"
+
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Break.vala:28
+msgid "Page break when exporting to PDF: <break>"
+msgstr "PDF へのエクスポート時のページ区切り: <break>"
+
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Break.vala:32
+msgid "Page break"
+msgstr "ページ区切り"
+
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Break.vala:47
+msgid "Page break on export: <break>"
+msgstr "エクスポート時のページ区切り: <break>"
+
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Highlight.vala:28
+msgid "Enable Syntax Highlighing"
+msgstr "シンタックスハイライトを有効化"
+
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Highlight.vala:32
+msgid "Syntax Highlighing"
+msgstr "シンタックスハイライト"
+
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Image.vala:28
+msgid "Load an embeded image"
+msgstr "埋め込まれた画像を読み込む"
+
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Image.vala:32
+msgid "Image"
+msgstr "画像"
+
+#: Services/FileManager.vala:197
+msgid "Select destination PDF file"
+msgstr "出力先の PDF ファイルを選択"
+
+#: Services/FileManager.vala:199
+msgid "Save"
+msgstr "保存"
+
+#: Services/FileManager.vala:202
+msgid "PDF File"
+msgstr "PDF ファイル"
+
+#: Services/FileManager.vala:209
+msgid "Open file"
+msgstr "ファイルを開く"
+
+#: Services/FileManager.vala:211
+msgid "Open"
+msgstr "開く"
+
+#: Services/FileManager.vala:214
+msgid "Images"
+msgstr "画像"
+
+#: Services/FileManager.vala:221
+msgid "All Files"
+msgstr "すべてのファイル"
+
+#: Widgets/Dialogs/PreferencesDialog.vala:133
+msgid "Spellcheck:"
+msgstr "スペルチェック:"
+

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-07-09 13:07-0500\n"
-"PO-Revision-Date: 2018-06-06 21:01+0900\n"
+"PO-Revision-Date: 2018-06-11 20:05+0900\n"
 "Last-Translator: Ryo Nakano <ryonakaknock@gmail.com>\n"
 "Language-Team: \n"
 "Language: ja\n"
@@ -116,27 +116,27 @@ msgstr "テキストに打ち消し線を引く"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:115
 msgid "Insert a quote"
-msgstr "引用を挿入する"
+msgstr "引用を挿入"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:116
 msgid "Insert code"
-msgstr "コードを挿入する"
+msgstr "コードを挿入"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:117
 msgid "Insert a link"
-msgstr "リンクを挿入する"
+msgstr "リンクを挿入"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:119
 msgid "Add a bulleted list"
-msgstr "箇条書きリストを追加する"
+msgstr "箇条書きリストを追加"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:120
 msgid "Add a Numbered list"
-msgstr "番号付きリストを追加する"
+msgstr "番号付きリストを追加"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:122
 msgid "Insert an image"
-msgstr "画像を挿入する"
+msgstr "画像を挿入"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:159
 msgid "Formatting"
@@ -172,7 +172,7 @@ msgstr "行番号の表示:"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:124
 msgid "Keep Sidebar Visible:"
-msgstr "サイドバーを表示する:"
+msgstr "サイドバーを表示:"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:152
 msgid "Global style modifications"
@@ -281,7 +281,7 @@ msgstr "リンク"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:56
 msgid "[Text](www...) "
-msgstr "[テキスト](www...)"
+msgstr "[テキスト](www...) "
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:57
 msgid "Citation Anchor"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,15 +7,15 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-07-09 13:07-0500\n"
-"PO-Revision-Date: 2018-03-21 20:12+0900\n"
-"Last-Translator: ryonakano <ryonakaknock@gmail.com>\n"
-"Language-Team: Japanese <kde-i18n-doc@kde.org>\n"
-"Language: ja_JP\n"
+"PO-Revision-Date: 2018-06-06 21:01+0900\n"
+"Last-Translator: Ryo Nakano <ryonakaknock@gmail.com>\n"
+"Language-Team: \n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Lokalize 2.0\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #: /home/felipe/Code/Notes-up/po/../src/Services/Page.vala:148
 #: /home/felipe/Code/Notes-up/po/../src/Services/Page.vala:212
@@ -152,7 +152,7 @@ msgstr "ビューアー"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:65
 msgid "_Close"
-msgstr "閉じる (_C)"
+msgstr "閉じる(_C)"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:73
 msgid "Font:"
@@ -380,7 +380,9 @@ msgstr "翻訳者のクレジット"
 msgid ""
 "Set font color for the line with <color [#color]> or for some text with "
 "<color [color] [text]>"
-msgstr "行の色を <color [#色]> で設定するか、テキストの色を <color [color] [text]> で設定してください"
+msgstr ""
+"行の色を <color [#色]> で設定するか、テキストの色を <color [color] "
+"[text]> で設定してください"
 
 #: /home/felipe/Code/Notes-up/po/../src/Plugins/Color.vala:39
 #: /home/felipe/Code/Notes-up/po/../src/Plugins/Color.vala:68
@@ -458,4 +460,3 @@ msgstr "すべてのファイル"
 #: Widgets/Dialogs/PreferencesDialog.vala:133
 msgid "Spellcheck:"
 msgstr "スペルチェック:"
-

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,14 +1,14 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 #
-# ryonakano <ryonakaknock@gmail.com>, 2018.
+# ryonakano <ryonakaknock3@gmail.com>, 2018.
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-07-09 13:07-0500\n"
 "PO-Revision-Date: 2018-06-11 20:05+0900\n"
-"Last-Translator: Ryo Nakano <ryonakaknock@gmail.com>\n"
+"Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
 "Language-Team: \n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"


### PR DESCRIPTION
Changes made in this pull request: 
- I've fixed some mistakes of Japanese translation for Notes-Up.
- I've re-added Japanese translation for Notes-Up.

I've pulled #255 previously, but I found there were some minor mistakes in the that translation. However, because I deleted my forked repo by mistake, I couldn't add more commits on that PR. So I created this new PR.
