### PR TITLE
German translation updated

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7,215 +7,383 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-09 13:07-0500\n"
-"PO-Revision-Date: 2017-08-03 20:37+0200\n"
-"Last-Translator: Benjamin Krala\n"
-"Language-Team: Benjamin Krala\n"
-"Language: de\n"
+"POT-Creation-Date: 2019-03-22 01:01-0600\n"
+"PO-Revision-Date: 2019-05-22 12:45+0200\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.4\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
+"Last-Translator: Patrick Becker <github@bec-wolke.de>\n"
+"Language: de\n"
 
-#: /home/felipe/Code/Notes-up/po/../src/Services/Page.vala:148
-#: /home/felipe/Code/Notes-up/po/../src/Services/Page.vala:212
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PagesList.vala:121
-msgid "New Page"
-msgstr "Neue Seite"
+#. / These keys must be valid since they will be used across the app
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:37
+msgid "<Ctrl>M"
+msgstr ""
 
-#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:150
-msgid "Print to File"
-msgstr "In Datei drucken"
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:38
+msgid "<Ctrl>S"
+msgstr ""
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar.vala:25
-msgid "Notebooks"
-msgstr "Notizbücher"
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:39
+msgid "<Ctrl>Q"
+msgstr ""
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar.vala:26
-msgid "Bookmarks"
-msgstr "Lesezeichen"
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:40
+msgid "<Ctrl><Shift>N"
+msgstr ""
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar.vala:27
-msgid "Trash"
-msgstr "Papierkorb"
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:41
+msgid "<Ctrl>F"
+msgstr ""
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar.vala:110
-msgid "My First Notebook"
-msgstr "Mein erstes Notizbuch"
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:42
+msgid "<Ctrl>K"
+msgstr ""
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/NotebookItem.vala:48
-msgid "Edit Notebook"
-msgstr "Notizbuch bearbeiten"
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:43
+msgid "<Ctrl>B"
+msgstr ""
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/NotebookItem.vala:49
-msgid "New Section"
-msgstr "Neuer Abschnitt"
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:44
+msgid "<Ctrl>I"
+msgstr ""
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/NotebookItem.vala:50
-msgid "Delete Notebook"
-msgstr "Notizbuch löschen"
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:45
+msgid "<Ctrl>T"
+msgstr ""
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Viewer.vala:23
-msgid "Default"
-msgstr "Standard"
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:46
+msgid "<Ctrl><Shift>I"
+msgstr "<Ctrl><Shift>I"
 
-# # Es handelt sich hier um Eigennamen. Diese werden daher nicht übersetzt.
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Viewer.vala:23
-msgid "Air"
-msgstr "Air"
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:65
+msgid "Notes-Up"
+msgstr "Notes-Up"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Viewer.vala:23
-msgid "Modest"
-msgstr "Modest"
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:66
+msgid "Your Markdown Notebook."
+msgstr "Dein Markdown-Notizbuch."
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:61
-msgid "View"
-msgstr "Ansicht"
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:67
+msgid "About Notes"
+msgstr "Über Notes-Up"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:62
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:81
-msgid "Edit"
-msgstr "Bearbeiten"
-
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:65
-msgid "Change mode"
-msgstr "Ändere Modus"
-
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:83
-msgid "Search your current notebook"
-msgstr "Aktuelles Notizbuch durchsuchen"
-
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:108
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:104
+#: /home/felipe/Code/Notes-up/po/../src/Application.vala:108
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:257
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/NotebookItem.vala:54
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/NotebookList.vala:32
 msgid "New Notebook"
 msgstr "Neues Notizbuch"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:109
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:43
-msgid "Preferences"
-msgstr "Einstellungen"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Break.vala:28
+msgid "Page break when exporting to PDF: <break>"
+msgstr "Seitenumbruch beim Export in eine PDF-Datei: <break>"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:110
-msgid "Export to PDF"
-msgstr "PDF exportieren"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Break.vala:32
+msgid "Page break"
+msgstr "Seitenumbruch"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/BookmarkButton.vala:44
-msgid "Bookmark page"
-msgstr "Lesezeichen hinzufügen"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Break.vala:47
+msgid "Page break on export: <break>"
+msgstr "Seitenumbruch beim Export: <break>"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:111
-msgid "Add bold to text"
-msgstr "Text fett formatieren"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Color.vala:35
+msgid ""
+"Set font color for the line with <color [#color]> or for some text with "
+"<color [color] [text]>"
+msgstr ""
+"Schriftfarbe in einer Textzeile mit <color [#Farbe]> oder für eine "
+"Textfolge mit <color [#Farbe] [Textfolge]> festlegen"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:112
-msgid "Add italic to text"
-msgstr "Text kursiv formatieren"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Color.vala:39
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Color.vala:68
+msgid "Font color"
+msgstr "Schriftfarbe"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:113
-msgid "Strikethrough text"
-msgstr "Text durchstreichen"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Highlight.vala:28
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:62
+msgid "Enable Syntax Highlighting"
+msgstr "Aktiviert Syntaxhervorhebung"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:115
-msgid "Insert a quote"
-msgstr "Zitat einfügen"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Highlight.vala:32
+msgid "Syntax Highlighing"
+msgstr "Syntaxhervorhebung"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:116
-msgid "Insert code"
-msgstr "Code einfügen"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Image.vala:28
+msgid "Load an embeded image"
+msgstr "Eingebettetes Bild laden"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:117
-msgid "Insert a link"
-msgstr "Link einfügen"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Image.vala:32
+msgid "Image"
+msgstr "Bild"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:119
-msgid "Add a bulleted list"
-msgstr "Aufzählung einfügen"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/PageLink.vala:31
+msgid "Open a page in Notes-Up"
+msgstr "Öffnen einer Seite in Notes-Up"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:120
-msgid "Add a Numbered list"
-msgstr "Nummerierte Liste einfügen"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/PageLink.vala:35
+msgid "Link to Page"
+msgstr "Link zur Seite"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:122
-msgid "Insert an image"
-msgstr "Bild einfügen"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Youtube.vala:30
+msgid "Embed youtube videos: <youtube [video]>"
+msgstr "Youtube Videos einbetten: <youtube [Video]>"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:159
-msgid "Formatting"
-msgstr "Formatierung"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Youtube.vala:34
+msgid "Youtube"
+msgstr "Youtube"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:51
-msgid "Editor"
-msgstr "Editor"
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Youtube.vala:42
+msgid "Insert Youtube video"
+msgstr "Youtube Video einfügen"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:52
-msgid "Viewer"
-msgstr "Ansicht"
+#. /:\=\+&\-'"]* is very greedy way for stating website but closer solutions need more space
+#: /home/felipe/Code/Notes-up/po/../src/Plugins/Youtube.vala:78
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:60
+msgid "Youtube Video"
+msgstr "Youtube Video"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:65
-msgid "_Close"
-msgstr "_Schließen"
+#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:158
+msgid "Print to File"
+msgstr "In Datei drucken"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:73
-msgid "Font:"
-msgstr "Schriftart:"
+#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:233
+msgid "Save as PDF"
+msgstr "Als PDF speichern"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:83
-msgid "Theme:"
-msgstr "Farbstil:"
+#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:235
+msgid "PDF File"
+msgstr "PDF-Datei"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:108
-msgid "Automatic indentation:"
-msgstr "Automatische Einrückung:"
+#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:243
+msgid "Save as Markdown"
+msgstr "Als Markdown speichern"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:116
-msgid "Show line Numbers:"
-msgstr "Zeilennummern anzeigen:"
+#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:245
+msgid "Markdown File"
+msgstr "Markdown Datei"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:124
-msgid "Keep Sidebar Visible:"
-msgstr "Seitenleiste immer anzeigen:"
+#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:253
+msgid "Open Image"
+msgstr "Bild öffnen"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:152
-msgid "Global style modifications"
-msgstr "Globale Stil-Änderungen"
+#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:256
+msgid "Images"
+msgstr "Bilder"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PreferencesDialog.vala:165
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:134
-msgid "Stylesheet:"
-msgstr "Formatvorlage:"
+#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:266
+msgid "Save"
+msgstr "Speichern"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:62
-msgid "Name:"
-msgstr "Name:"
+#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:268
+msgid "Open"
+msgstr "Öffnen"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:63
-msgid "Color:"
-msgstr "Farbe:"
+#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:272
+msgid "All Files"
+msgstr "Alle Dateien"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:71
+#: /home/felipe/Code/Notes-up/po/../src/Services/FileManager.vala:281
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NewNotebookDialog.vala:72
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NotebookListDialog.vala:34
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NotebookListDialog.vala:75
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:84
+#: /home/felipe/Code/Notes-up/po/../src/Services/Page.vala:177
+#: /home/felipe/Code/Notes-up/po/../src/Services/Page.vala:261
+#: /home/felipe/Code/Notes-up/po/../src/Services/Page.vala:272
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PagesList.vala:101
+msgid "New Page"
+msgstr "Neue Seite"
+
+#: /home/felipe/Code/Notes-up/po/../src/Services/StyleLoader.vala:23
+msgid "Default"
+msgstr "Standard"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/BookmarkButton.vala:34
+msgid "Bookmark page"
+msgstr "Lesezeichen hinzufügen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NewNotebookDialog.vala:63
+msgid "Name:"
+msgstr "Name:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NewNotebookDialog.vala:64
+msgid "Color:"
+msgstr "Farbe:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NewNotebookDialog.vala:82
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:202
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NewNotebookDialog.vala:85
 msgid "Create"
 msgstr "Erstellen"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:102
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NewNotebookDialog.vala:103
 msgid "Properties"
 msgstr "Einstellungen"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:103
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NewNotebookDialog.vala:104
 msgid "Style"
 msgstr "Stil"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/NewNotebookDialog.vala:121
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NewNotebookDialog.vala:122
 msgid "Style modifications"
 msgstr "Stilabwandlungen"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/TrashItem.vala:28
-msgid "Restore"
-msgstr "Wiederherstellen"
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NewNotebookDialog.vala:135
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/PreferencesDialog.vala:161
+msgid "Stylesheet:"
+msgstr "Formatvorlage:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NotebookListDialog.vala:25
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/NotebookItem.vala:56
+msgid "Move Notebook"
+msgstr "Notizbuch verschieben"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NotebookListDialog.vala:36
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NotebookListDialog.vala:77
+msgid "Move"
+msgstr "Verschieben"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/NotebookListDialog.vala:65
+msgid "Move Page"
+msgstr "Seite verschieben"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/PreferencesDialog.vala:42
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:260
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/PreferencesDialog.vala:51
+msgid "Editor"
+msgstr "Editor"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/PreferencesDialog.vala:52
+msgid "Viewer"
+msgstr "Ansicht"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/PreferencesDialog.vala:65
+msgid "_Close"
+msgstr "_Schließen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/PreferencesDialog.vala:73
+msgid "Font:"
+msgstr "Schriftart:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/PreferencesDialog.vala:83
+msgid "Theme:"
+msgstr "Farbstil:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/PreferencesDialog.vala:94
+msgid "Automatic indentation:"
+msgstr "Automatische Einrückung:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/PreferencesDialog.vala:102
+msgid "Show line Numbers:"
+msgstr "Zeilennummern anzeigen:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/PreferencesDialog.vala:110
+msgid "Keep Sidebar Visible:"
+msgstr "Seitenleiste immer anzeigen:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/PreferencesDialog.vala:118
+msgid "Spellcheck:"
+msgstr "Rechtschreibprüfung:"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Dialogs/PreferencesDialog.vala:148
+msgid "Global style modifications"
+msgstr "Globale Stil-Änderungen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:157
+msgid "Add bold to text"
+msgstr "Text fett formatieren"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:164
+msgid "Add italic to text"
+msgstr "Text kursiv formatieren"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:171
+msgid "Strikethrough text"
+msgstr "Text durchstreichen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:175
+msgid "Insert a quote"
+msgstr "Zitat einfügen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:176
+msgid "Insert code"
+msgstr "Code einfügen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:177
+msgid "Insert a link"
+msgstr "Link einfügen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:179
+msgid "Add a bulleted list"
+msgstr "Aufzählung einfügen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:180
+msgid "Add a Numbered list"
+msgstr "Nummerierte Liste einfügen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:182
+msgid "Insert an image"
+msgstr "Bild einfügen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Editor.vala:221
+msgid "Formatting"
+msgstr "Formatierung"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:59
+msgid "Search your current notebook"
+msgstr "Aktuelles Notizbuch durchsuchen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:84
+msgid "Add Tag"
+msgstr "Tag hinzufügen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:113
+msgid "Edit Page Title"
+msgstr "Seitentitel bearbeiten"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:201
+msgid "View"
+msgstr "Ansicht"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:205
+msgid "Change mode"
+msgstr "Ändere Modus"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:229
+msgid "High Contrast"
+msgstr "Hoher Kontrast"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:237
+msgid "Solarized Light"
+msgstr "Solarisiertes Licht"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:245
+msgid "Solarized Dark"
+msgstr "Solarisierte Dunkelheit"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:263
+msgid "Export as PDF"
+msgstr "Als PDF exportieren"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:266
+msgid "Export as Markdown"
+msgstr "Als Markdown exportieren"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Headerbar.vala:289
+msgid "Menu"
+msgstr "Menü"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:41
 msgid "Large Header"
@@ -283,7 +451,7 @@ msgstr "Link"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:56
 msgid "[Text](www...) "
-msgstr "[Text](www...)"
+msgstr "[Text](www...) "
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:57
 msgid "Citation Anchor"
@@ -294,10 +462,6 @@ msgid "Citation Text"
 msgstr "Ausführung zum Textbeleg"
 
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:60
-msgid "Youtube Video"
-msgstr "Youtube Video"
-
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:60
 msgid "<youtube [link]>"
 msgstr "<youtube [Link]>"
 
@@ -305,161 +469,102 @@ msgstr "<youtube [Link]>"
 msgid "Page Break (when exporting)"
 msgstr "Seitenumbruch (Nur beim Export)"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:62
-msgid "Enable Syntax Highlighting"
-msgstr "Aktiviert Syntaxhervorhebung"
-
 #: /home/felipe/Code/Notes-up/po/../src/Widgets/HelpBox.vala:63
 msgid "Set Color"
 msgstr "Farbe einstellen"
 
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PageInfoEditor.vala:71
+#, c-format
+msgid "Created: %s"
+msgstr "Erstellt: %s"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PageInfoEditor.vala:78
+#, c-format
+msgid "Updated: %s"
+msgstr "Verändert: %s"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PageInfoEditor.vala:100
+msgid "Not in Notebook"
+msgstr "Nicht im Notebook"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PageInfoEditor.vala:127
+msgid "Move page…"
+msgstr "Seite verschieben…"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PageInfoEditor.vala:163
+msgid "Copy link to page to clipboard"
+msgstr "Seitenlink in die Zwischenablage kopieren"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PageInfoEditor.vala:195
+msgid "Toggle page information"
+msgstr "Seiteninformationen umschalten"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PageInfoEditor.vala:223
+msgid "Link to: "
+msgstr "Link nach: "
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PageInfoEditor.vala:265
+msgid "Click to add tag…"
+msgstr "Hier klicken, um einen Tag hinzuzufügen…"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PageInfoEditor.vala:329
+msgid "Remove tag"
+msgstr "Tag entfernen"
+
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PagesList.vala:106
+msgid "Delete Page"
+msgstr "Seite Löschen"
+
 #. //bugzilla.gnome.org/show_bug.cgi?id=758000 is fixed.
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PagesList.vala:201
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/PagesList.vala:300
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PagesList.vala:227
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/PagesList.vala:353
 #, c-format
 msgid "%i Page"
 msgid_plural "%i Pages"
 msgstr[0] "%i Seite"
 msgstr[1] "%i Seiten"
 
-#: /home/felipe/Code/Notes-up/po/../src/Widgets/BookmarkItem.vala:54
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/BookmarkItem.vala:54
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/TagItem.vala:54
 msgid "Remove"
 msgstr "Entfernen"
 
-#. / These keys must be valid since they will be used across the app
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:36
-msgid "<Ctrl>M"
-msgstr ""
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/NotebookItem.vala:53
+msgid "Edit Notebook"
+msgstr "Notizbuch bearbeiten"
 
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:37
-msgid "<Ctrl>S"
-msgstr ""
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/NotebookItem.vala:55
+msgid "Delete Notebook"
+msgstr "Notizbuch löschen"
 
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:38
-msgid "<Ctrl>Q"
-msgstr ""
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/Sidebar.vala:27
+msgid "Bookmarks"
+msgstr "Lesezeichen"
 
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:39
-msgid "<Ctrl><Shift>N"
-msgstr ""
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/Sidebar.vala:28
+msgid "Trash"
+msgstr "Papierkorb"
 
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:40
-msgid "<Ctrl>F"
-msgstr ""
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/Sidebar.vala:29
+msgid "Tags"
+msgstr "Tags"
 
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:41
-msgid "<Ctrl>K"
-msgstr ""
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/Sidebar.vala:33
+msgid "Notebooks"
+msgstr "Notizbücher"
 
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:42
-msgid "<Ctrl>B"
-msgstr ""
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/Sidebar.vala:54
+msgid "All Notes"
+msgstr "Alle Notizen"
 
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:43
-msgid "<Ctrl>I"
-msgstr ""
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/Sidebar.vala:79
+msgid "Not in a Notebook"
+msgstr "Nicht in einem Notizbuch"
 
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:44
-msgid "<Ctrl>T"
-msgstr ""
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/Sidebar.vala:205
+msgid "My First Notebook"
+msgstr "Mein erstes Notizbuch"
 
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:62
-msgid "Notes-Up"
-msgstr "Notes-Up"
-
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:63
-msgid "Your Markdown Notebook."
-msgstr "Dein Markdown-Notizbuch"
-
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:64
-msgid "About Notes"
-msgstr "Über Notes-Up"
-
-#: /home/felipe/Code/Notes-up/po/../src/Application.vala:82
-msgid "translator-credits"
-msgstr "Benjamin Krala"
-
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Color.vala:35
-msgid ""
-"Set font color for the line with <color [#color]> or for some text with "
-"<color [color] [text]>"
-msgstr ""
-"Schriftfarbe in einer Textzeile mit <color [#Farbe]> oder für eine Textfolge "
-"mit <color [#Farbe] [Textfolge]> festlegen"
-
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Color.vala:39
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Color.vala:68
-msgid "Font color"
-msgstr "Schriftfarbe"
-
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Youtube.vala:30
-msgid "Embed youtube videos: <youtube [video]>"
-msgstr "Youtube Videos einbetten: <youtube [Video]>"
-
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Youtube.vala:34
-msgid "Youtube"
-msgstr "Youtube"
-
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Youtube.vala:42
-msgid "Insert Youtube video"
-msgstr "Youtube Video einfügen"
-
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Break.vala:28
-msgid "Page break when exporting to PDF: <break>"
-msgstr "Seitenumbruch beim Export in eine PDF-Datei: <break>"
-
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Break.vala:32
-msgid "Page break"
-msgstr "Seitenumbruch"
-
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Break.vala:47
-msgid "Page break on export: <break>"
-msgstr "Seitenumbruch beim Export: <break>"
-
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Highlight.vala:28
-msgid "Enable Syntax Highlighing"
-msgstr "Aktiviert Syntaxhervorhebung"
-
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Highlight.vala:32
-msgid "Syntax Highlighing"
-msgstr "Syntaxhervorhebung"
-
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Image.vala:28
-msgid "Load an embeded image"
-msgstr "Eingebettetes Bild laden "
-
-#: /home/felipe/Code/Notes-up/po/../src/Plugins/Image.vala:32
-msgid "Image"
-msgstr "Bild"
-
-#: Services/FileManager.vala:197
-msgid "Select destination PDF file"
-msgstr "Speicherort für PDF-Datei auswählen"
-
-#: Services/FileManager.vala:199
-msgid "Save"
-msgstr "Speichern"
-
-#: Services/FileManager.vala:202
-msgid "PDF File"
-msgstr "PDF-Datei"
-
-#: Services/FileManager.vala:209
-msgid "Open file"
-msgstr "Öffne Datei"
-
-#: Services/FileManager.vala:211
-msgid "Open"
-msgstr "Öffnen"
-
-#: Services/FileManager.vala:214
-msgid "Images"
-msgstr "Bilder"
-
-#: Services/FileManager.vala:221
-msgid "All Files"
-msgstr "Alle Dateien"
-
-#: Widgets/Dialogs/PreferencesDialog.vala:133
-msgid "Spellcheck:"
-msgstr "Rechtschreibprüfung"
+#: /home/felipe/Code/Notes-up/po/../src/Widgets/Sidebar/TrashItem.vala:28
+msgid "Restore"
+msgstr "Wiederherstellen"


### PR DESCRIPTION
New German translation created from the template.

- No longer needed translations removed.
- Missing translations added.

There is a missing translation in the **time field**. _(See upper red marked places)_
In the file `PageInfoEditor.vala` _(Line 71 and 77)_ the function `date.to_string ()` returns the time in English format, for this problem I could not find a solution on the fast one.

The text **_Mein Notizbuch_** is difficult to read in the dark design. Is it a good idea to add a check if the dark design is used, lighten up the text color to 60%?

### Changes
![github_changes](https://user-images.githubusercontent.com/29308797/58170706-816e3c00-7c94-11e9-86e9-0df7a8534786.png)

