### PR TITLE
Enforce referential integrity

### DIFF
--- a/src/Services/Image.vala
+++ b/src/Services/Image.vala
@@ -58,6 +58,7 @@ public class ENotes.ImageTable : DatabaseTable {
 
     public static ImageTable get_instance () {
         if (instance == null) {
+            PageTable.get_instance ();
             instance = new ImageTable ();
         }
 
@@ -70,6 +71,7 @@ public class ENotes.ImageTable : DatabaseTable {
                                  + "page_id INTEGER NOT NULL, "
                                  + "format INTEGER, "
                                  + "data BLOB, "
+                                 + "FOREIGN KEY (page_id) REFERENCES Page(id), "
                                  + "PRIMARY KEY (id, page_id))");
         var res = stmt.step ();
 

--- a/src/Services/Page.vala
+++ b/src/Services/Page.vala
@@ -58,6 +58,7 @@ public class ENotes.PageTable : DatabaseTable {
 
     public static PageTable get_instance () {
         if (instance == null) {
+            NotebookTable.get_instance ();
             instance = new PageTable ();
         }
 
@@ -73,7 +74,8 @@ public class ENotes.PageTable : DatabaseTable {
                                  + "html_cache TEXT NOT NULL DEFAULT '', "
                                  + "creation_date INTEGER,"
                                  + "modification_date INTEGER,"
-                                 + "notebook_id INTEGER)");
+                                 + "notebook_id INTEGER,"
+                                 + "FOREIGN KEY (notebook_id) REFERENCES Notebook(id))");
         var res = stmt.step ();
 
         if (res != Sqlite.DONE)

--- a/src/Services/Tags.vala
+++ b/src/Services/Tags.vala
@@ -30,6 +30,7 @@ public class ENotes.TagsTable : DatabaseTable {
 
     public static TagsTable get_instance () {
         if (instance == null) {
+            PageTable.get_instance ();
             instance = new TagsTable ();
         }
 
@@ -49,7 +50,9 @@ public class ENotes.TagsTable : DatabaseTable {
 
         stmt = create_stmt ("CREATE TABLE IF NOT EXISTS TagsPage ("
             + "page_id INTEGER, "
-            + "tag_id INTEGER)");
+            + "tag_id INTEGER, "    
+            + "FOREIGN KEY(page_id) REFERENCES Page(id), "
+            + "FOREIGN KEY(tag_id) REFERENCES Tags(id))");
 
         res = stmt.step ();
 


### PR DESCRIPTION
That thing I said I'd get to way back in #299.

Just basic referential integrity.

Note that this won't affect any existing databases. The get_instance() method of the singleton classes is modified to guarantee tables are built in the correct order.