### PR TITLE
Use sudo only to install, not to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ For advanced users!
 	cd Notes-up
 	mkdir build && cd build
 	cmake -DCMAKE_INSTALL_PREFIX=/usr ../
+	make
 	sudo make install
 
 If you are building on a distribution which is not elementary, you need to add `-Dnoele=1` when running cmake.


### PR DESCRIPTION
Build the software with make without sudo because you don't want all intermediate files to be owned by root. Use sudo only when required (for make install).

<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference -->

## Summary / How this PR fixes the problem?

No code change (readme file only).

## Steps to Test

n/a

## Screenshots

n/a

## Known Issues / Things To Do

n/a

## This PR fixes/implements the following **bugs/features**:

n/a
