### PR TITLE
Add missing icon

### DIFF
--- a/data/assets.gresource.xml
+++ b/data/assets.gresource.xml
@@ -11,6 +11,7 @@
     <file alias="panes-two-symbolic.svg" compressed="false" preprocess="">icons/symbolic/panes-two-symbolic.svg</file>
     <file alias="panes-one-symbolic.svg" compressed="false" preprocess="">icons/symbolic/panes-one-symbolic.svg</file>
     <file alias="panes-none-symbolic.svg" compressed="false" preprocess="">icons/symbolic/panes-none-symbolic.svg</file>
+    <file alias="tag-symbolic.svg" compressed="false" preprocess="">icons/symbolic/tag-symbolic.svg</file>
   </gresource>
   <gresource prefix="/com/github/philip-scott/notes-up/">
     <file alias="Application.css" compressed="true">assets/stylesheets/app/Application.css</file>

--- a/data/icons/symbolic/tag-symbolic.svg
+++ b/data/icons/symbolic/tag-symbolic.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" height="16" width="16" id="svg2" version="1.1">
+  <metadata id="metadata12">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id="defs10"/>
+  <path style="fill:#666666;fill-rule:evenodd" id="path6" d="m 8.5,1 -7.25,7.75 6,6 L 15,7.5 15,3 C 15,1 13,1 13,1 Z M 12,3 c 1.333333,0 1.333333,2 0,2 -1.333333,0 -1.333333,-2 0,-2 z"/>
+</svg>


### PR DESCRIPTION
The tag-symbolic icon is missing from the default Adwaita icon theme. Add it from Elementary to provide fallback.