### PR TITLE
AppData: Add legacy RDNN to provides tag

### DIFF
--- a/data/com.github.philip_scott.notes-up.appdata.xml.in
+++ b/data/com.github.philip_scott.notes-up.appdata.xml.in
@@ -22,6 +22,8 @@
     </description>
   <provides>
     <binary>com.github.philip_scott.notes-up</binary>
+    <!-- legacy RDNN -->
+    <id>com.github.philip-scott.notes-up</id>
   </provides>
   <releases>
     <release version="2.0.6" date="2021-11-29">


### PR DESCRIPTION
Recommended by [the AppStream spec](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#id-1.3.6.4.3.11.2.3.10), and will allow us to deduplicate the old and current app listings; see https://github.com/elementary/appcenter-web/issues/79