### PR TITLE
Set window icon

### DIFF
--- a/src/Main.vala
+++ b/src/Main.vala
@@ -27,7 +27,8 @@ public static int main (string[] args) {
     Intl.setlocale (LocaleCategory.ALL, Intl.get_language_names ()[0]);
 
     Environment.set_application_name (APP_NAME);
-    Environment.set_prgname (APP_NAME);
+    Environment.set_prgname ("com.github.philip_scott.notes-up");
+    Gtk.Window.set_default_icon_name ("com.github.philip_scott.notes-up");
 
     var application = new ENotes.Application ();
 


### PR DESCRIPTION
- `g_set_prgname()` is needed for Wayland compositors to match the window with the desktop file. ([reference](https://honk.sigxcpu.org/con/GTK__and_the_application_id.html))
- `gtk_window_set_default_icon_name()` is needed for taskbars and window managers on X11 to have window icon.