### PR TITLE
Set window title to null when nothing is selected

### DIFF
--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -447,7 +447,7 @@ public class ENotes.Headerbar : Gtk.HeaderBar {
         } else if (notebook_title != null) {
             this.title = notebook_title;
         } else {
-            this.title = "";
+            this.title = null;
         }
 
         this.title = this.title.replace ("&amp;", "&");


### PR DESCRIPTION
When the window title is null, it falls back to the application name instead of setting an empty string.
